### PR TITLE
compose: A/B LUN0 layout — dual system + dual EFI, persistent grow userdata

### DIFF
--- a/compose_24_04.sh
+++ b/compose_24_04.sh
@@ -193,11 +193,16 @@ echo "OK: signed bootbinaries -> $SIGNED_BOOTBIN_ZIP"
 
 # ---- 6) assemble (ptool + partition_ext) ------------------------------------
 section "6) assemble factory image (ptool)"
+# A/B: the one rootfs.ext4 / efi.img is written to BOTH slots at factory (same source file,
+# stored once in the zip, referenced twice), matching the 20.04 dual-slot flash. OTA rewrites
+# only the inactive slot later.
 "$PROJ/scripts/assemble/make_factory_img.sh" \
   --bootbinaries "$SIGNED_BOOTBIN_ZIP" \
-  --system       "$ROOTFS" \
+  --system_a     "$ROOTFS" \
+  --system_b     "$ROOTFS" \
   --dtb_a        "$OUT/dtb.img" \
-  --efi          "$OUT/efi.img" \
+  --efi_a        "$OUT/efi.img" \
+  --efi_b        "$OUT/efi.img" \
   --core_nhlos_a "$OUT/nonhlos.img" \
   --output       "$OUT/factory"
 

--- a/scripts/assemble/config/partition_ext.xml
+++ b/scripts/assemble/config/partition_ext.xml
@@ -12,11 +12,20 @@
     <!-- NOTE: "physical_partition" are listed in order and apply to UFS devices that have physical partitions -->
 
     <!-- This is LUN 0 - HLOS LUN" -->
+    <!-- A/B layout. efi_a/efi_b and system_a/system_b are dual slots written with the SAME image
+         at factory (composer passes the one rootfs.ext4 / efi.img to both); OTA later rewrites the
+         inactive slot. persist and userdata are NOT slotted: they survive A/B switches. userdata is
+         the LAST partition so GROW_LAST_PARTITION_TO_FILL_DISK expands it to use all remaining flash
+         (dynamic per device: ~30GB spare on a 64GB SKU, ~90GB on 128GB), with a 4GB floor. A/B
+         partitions need distinct type GUIDs (same convention as the firmware slots on LUN4). -->
     <physical_partition>
-        <partition label="efi" 			    size_in_kb="524288" 	type="C12A7328-F81F-11D2-BA4B-00A0C93EC93B" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="efi.bin"/>
-		<partition label="persist" 		    size_in_kb="30720" 		type="0FC63DAF-8483-4772-8E79-3D69D8477DE4" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>	
-		<partition label="system" 		    size_in_kb="10485760" 	type="B921B045-1DF0-41C3-AF44-4C6F280D3FAE" bootable="false" readonly="false" 	system="true" dontautomount="true" filename="system.img"/> 
-	</physical_partition>                   
+        <partition label="efi_a" 		    size_in_kb="524288" 	type="C12A7328-F81F-11D2-BA4B-00A0C93EC93B" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="efi.bin"/>
+        <partition label="efi_b" 		    size_in_kb="524288" 	type="FFFE4A7E-CB5C-4290-87D9-4B7C5B994CA5" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
+        <partition label="system_a" 	    size_in_kb="12582912" 	type="B921B045-1DF0-41C3-AF44-4C6F280D3FAE" bootable="false" readonly="false" 	system="true" dontautomount="true" filename="system.img"/>
+        <partition label="system_b" 	    size_in_kb="12582912" 	type="7BE0A15B-8445-4339-87BB-CC1689341695" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+		<partition label="persist" 		    size_in_kb="30720" 		type="0FC63DAF-8483-4772-8E79-3D69D8477DE4" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+		<partition label="userdata" 	    size_in_kb="4194304" 	type="62570D05-184E-4CD9-8111-9F594640977D" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+	</physical_partition>
 										    
     <!-- This is LUN 1 - Boot LUN A" -->    
     <physical_partition>                    


### PR DESCRIPTION
## What

Reworks the LUN0 (HLOS) partition layout from single-slot to **A/B**, addressing four requirements:

| # | Requirement | Done |
|---|---|---|
| (a) | A/B boot with **dual system images** | `system_a` + `system_b`, both flashed with `rootfs.ext4` |
| (b) | EFI FAT sized for the kernel eventually | 512 MB per slot (holds GRUB + kernel + initramfs with headroom) |
| (c) | 4 GB persistent user disk, **not reset over A/B** | `userdata`, grow-to-fill, 4 GB floor, not slotted |
| (d) | EFI FAT **A/B** | `efi_a` + `efi_b`, both flashed with `efi.img` |

### LUN0 (the whole disk)
```
efi_a        512 MB   ESP, slot A        <- efi.img
efi_b        512 MB   ESP, slot B        <- efi.img
system_a     12 GB    fixed, slot A      <- rootfs.ext4
system_b     12 GB    fixed, slot B      <- rootfs.ext4
persist      30 MB    not slotted (survives A/B)
userdata     GROW     last partition, 4 GB floor, not slotted
```

### Why these sizes
- **`system_a`/`system_b` must be fixed** — only the *last* partition of a LUN can grow, and you can't grow two. They're sized to fit the **64 GB** SKU: `2×12 + 2×0.5 + 0.03 = 25 GB` fixed.
- **`userdata` is the grow partition** — `provision_ufs22.xml` already grows LUN0 to fill the device (`LUNtoGrow=0`), so userdata absorbs the SKU difference: **~30 GB on 64 GB, ~90 GB on 128 GB**. It's not slotted, so OTA (which rewrites the inactive `system`/`efi`) never touches it.
- Both slots are written at factory from a single source image (stored once in the zip, referenced twice) — same as the 20.04 dual-slot flash.

### Verification
- ptool runs clean over the new table; `rawprogram0` shows the six partitions with correct sizes and `userdata` as grow (`num_partition_sectors=0`).
- Confirmed `make_factory_img.sh` substitution populates **both** `system_a`/`system_b` → `rootfs.ext4` and `efi_a`/`efi_b` → `efi.img`.

## Not in this PR (makes slot B actually *bootable*)
This lands the partition **structure**. Functional A/B still needs:
- **Firmware-B blobs** populated (LUN4 `*_b` are still empty holes).
- **UEFI slot-switch policy** + per-slot **GRUB** so the bootloader picks the active slot's ESP.
- **userdata first-boot `mkfs` + fstab mount** (partition is defined but unformatted).
- Minor: `growfs.sh` fallback default (`system_a`) — already resizes the mounted root via `findmnt`, so low-risk; worth making slot-aware (overlays repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)