### PR TITLE
hotfix: pin 24.04 default to 1.1.43 (stop CLI serving 1.2.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,6 +528,64 @@ jobs:
             release_metadata.json \
             --origin "24.04"
 
+      # ----------------------------------------------------------------------
+      # HACK (temporary): the 24.04 line (1.2.x new-BP/A/B) is not production
+      # stable, so the CLI must not serve it as the default. Pin the published
+      # 24.04 entries to the last good release (1.1.43, desktop only — 1.1.43
+      # never shipped a 24.04 headless image) in BOTH the `latest` channel
+      # (force-replacing whatever this release just published) and a `stable`
+      # channel (seeded here). Touches ONLY the 24.04 builds; every other
+      # distribution (20.04, android, …) in the manifests is left untouched.
+      # sha256_checksum is intentionally empty — 1.1.43 published no checksum
+      # and the CLI skips verification when it is absent. REMOVE this step once
+      # a real 24.04 stable ships and update the generation to publish it.
+      # ----------------------------------------------------------------------
+      - name: 'HACK: pin 24.04 to 1.1.43 (desktop) in latest + stable'
+        if: env.PUSH_JSON == 'true'
+        env:
+          PIN_VERSION: '1.1.43'
+          LATEST_KEY: ${{ vars.RELEASE_METADATA_KEY || 'meta/tachyon-latest.json' }}
+          STABLE_KEY: 'meta/tachyon-stable.json'
+          CF_DIST_ID: ${{ secrets.LINUX_DIST_CLOUDFRONT_DISTRIBUTION_ID }}
+          BASE_URL: ${{ vars.PUBLIC_RELEASE_BASE_URL || 'https://linux-dist.particle.io/release' }}
+        run: |
+          set -euo pipefail
+
+          # The two pinned 1.1.43 24.04 desktop builds (NA + RoW). No headless
+          # (1.1.43 has none). sha256_checksum left "" so the CLI does not verify.
+          PINNED="$(jq -n --arg ver "$PIN_VERSION" '
+            ["NA","RoW"] | map({
+              release_name: ("tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver),
+              version: $ver, region: ., variant: "desktop",
+              platform: "qcm6490", board: "formfactor_dvt",
+              os: "linux", distribution: "ubuntu",
+              distribution_version: "24.04", distribution_variant: "ubuntu",
+              artifacts: [{
+                artifact_url: ("https://linux-dist.particle.io/releases/" + $ver + "/" + . + "/tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver + ".zip"),
+                sha256_checksum: "", type: "release_image"
+              }]
+            })')"
+
+          # Replace ONLY the 24.04 builds in a manifest, preserving all others.
+          # $1 = s3 key, $2 = fallback skeleton if the object does not exist yet.
+          pin_24_04 () {
+            local key="$1" skeleton="$2" cur
+            cur="$(aws s3 cp "s3://${LINUX_DIST_S3_BUCKET}/${key}" - 2>/dev/null || echo "$skeleton")"
+            echo "$cur" | jq --argjson pinned "$PINNED" \
+              '.builds = ([.builds[]? | select(.distribution_version != "24.04")] + $pinned)' \
+              | aws s3 cp - "s3://${LINUX_DIST_S3_BUCKET}/${key}" --content-type application/json --only-show-errors
+            echo "pinned 24.04 -> ${PIN_VERSION} in ${key}"
+          }
+
+          SKEL='{"$schema":"https://linux-dist.particle.io/schema/release_metadata_v1.json","builds":[]}'
+          pin_24_04 "$LATEST_KEY" "$SKEL"   # force-replace 24.04 in latest
+          pin_24_04 "$STABLE_KEY" "$SKEL"   # seed/replace 24.04 in stable
+
+          if [ -n "${CF_DIST_ID:-}" ]; then
+            aws cloudfront create-invalidation --distribution-id "$CF_DIST_ID" \
+              --paths "/${LATEST_KEY}" "/${STABLE_KEY}"
+          fi
+
       - name: S3 metadata (dry run)
         if: env.PUSH_JSON != 'true'
         run: echo "PUSH_JSON != 'true' -- dry run, nothing pushed to S3."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -547,13 +547,15 @@ jobs:
           LATEST_KEY: ${{ vars.RELEASE_METADATA_KEY || 'meta/tachyon-latest.json' }}
           STABLE_KEY: 'meta/tachyon-stable.json'
           CF_DIST_ID: ${{ secrets.LINUX_DIST_CLOUDFRONT_DISTRIBUTION_ID }}
-          BASE_URL: ${{ vars.PUBLIC_RELEASE_BASE_URL || 'https://linux-dist.particle.io/release' }}
+          # Released 24.04 images live at /releases/<ver>/<region>/ (verified HTTP 200);
+          # this matches the existing 24.04 entries, NOT the singular /release/ that 20.04 uses.
+          RELEASES_BASE_URL: 'https://linux-dist.particle.io/releases'
         run: |
           set -euo pipefail
 
           # The two pinned 1.1.43 24.04 desktop builds (NA + RoW). No headless
           # (1.1.43 has none). sha256_checksum left "" so the CLI does not verify.
-          PINNED="$(jq -n --arg ver "$PIN_VERSION" '
+          PINNED="$(jq -n --arg ver "$PIN_VERSION" --arg base "$RELEASES_BASE_URL" '
             ["NA","RoW"] | map({
               release_name: ("tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver),
               version: $ver, region: ., variant: "desktop",
@@ -561,25 +563,41 @@ jobs:
               os: "linux", distribution: "ubuntu",
               distribution_version: "24.04", distribution_variant: "ubuntu",
               artifacts: [{
-                artifact_url: ("https://linux-dist.particle.io/releases/" + $ver + "/" + . + "/tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver + ".zip"),
+                artifact_url: ($base + "/" + $ver + "/" + . + "/tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver + ".zip"),
                 sha256_checksum: "", type: "release_image"
               }]
             })')"
 
           # Replace ONLY the 24.04 builds in a manifest, preserving all others.
-          # $1 = s3 key, $2 = fallback skeleton if the object does not exist yet.
+          # $1 = s3 key, $2 = "seed" to allow creating the object when it genuinely
+          # does not exist (404). We check existence with head-object FIRST: if the
+          # object exists we MUST read it successfully (set -e aborts on a transient
+          # read failure) so we never silently fall back to an empty skeleton and
+          # clobber the other distributions; the skeleton is used ONLY for a true 404.
           pin_24_04 () {
-            local key="$1" skeleton="$2" cur
-            cur="$(aws s3 cp "s3://${LINUX_DIST_S3_BUCKET}/${key}" - 2>/dev/null || echo "$skeleton")"
-            echo "$cur" | jq --argjson pinned "$PINNED" \
-              '.builds = ([.builds[]? | select(.distribution_version != "24.04")] + $pinned)' \
-              | aws s3 cp - "s3://${LINUX_DIST_S3_BUCKET}/${key}" --content-type application/json --only-show-errors
+            local key="$1" mode="$2" cur new
+            if aws s3api head-object --bucket "$LINUX_DIST_S3_BUCKET" --key "$key" >/dev/null 2>&1; then
+              cur="$(aws s3 cp "s3://${LINUX_DIST_S3_BUCKET}/${key}" -)"
+            elif [ "$mode" = "seed" ]; then
+              echo "note: ${key} does not exist yet; seeding a new manifest"
+              cur="$SKEL"
+            else
+              echo "ERROR: ${key} not found (or unreadable); refusing to overwrite it from an empty skeleton" >&2
+              exit 1
+            fi
+            # Build + sanity-check the result in memory BEFORE uploading, so a jq
+            # failure can never write a truncated/empty object to S3.
+            new="$(printf '%s' "$cur" | jq --argjson pinned "$PINNED" \
+              '.builds = ([.builds[]? | select(.distribution_version != "24.04")] + $pinned)')"
+            printf '%s' "$new" | jq -e '.builds | length > 0' >/dev/null
+            printf '%s' "$new" | aws s3 cp - "s3://${LINUX_DIST_S3_BUCKET}/${key}" \
+              --content-type application/json --only-show-errors
             echo "pinned 24.04 -> ${PIN_VERSION} in ${key}"
           }
 
           SKEL='{"$schema":"https://linux-dist.particle.io/schema/release_metadata_v1.json","builds":[]}'
-          pin_24_04 "$LATEST_KEY" "$SKEL"   # force-replace 24.04 in latest
-          pin_24_04 "$STABLE_KEY" "$SKEL"   # seed/replace 24.04 in stable
+          pin_24_04 "$LATEST_KEY" require   # latest MUST exist; never seed/clobber
+          pin_24_04 "$STABLE_KEY" seed      # stable may not exist yet; seed if 404
 
           if [ -n "${CF_DIST_ID:-}" ]; then
             aws cloudfront create-invalidation --distribution-id "$CF_DIST_ID" \


### PR DESCRIPTION
## Problem
The CLI serves **1.2.1** as the default 24.04 image. Its 24.04 path reads the `latest` channel (`tachyon-latest.json`, hardcoded `version: 'latest'` in particle-cli `workflow.js`), and that manifest's 24.04 entries were force-bumped to 1.2.1 when the 1.2.1 release published its metadata. 1.2.x is the in-development new-BP / A/B line — not production stable.

## Fix (manifest-generation hack, only touches 24.04)
Adds a step in `build.yml` `publish_release` that, after the normal metadata push:
- **force-replaces** the 24.04 entries in `meta/tachyon-latest.json` with the last good release **1.1.43**, and
- **seeds a `meta/tachyon-stable.json`** with the same 24.04 entries (the requested stable structure).

Details:
- **Desktop only** (NA + RoW). 1.1.43 never shipped a 24.04 *headless* image (confirmed: the 1.1.43 GitHub release lists only desktop links; headless URLs 404), so no headless entry is emitted.
- **Only the 24.04 builds are touched** — 20.04 (1.0.181), android, manufacturing, etc. are preserved verbatim. Verified by dry-running the jq transform against the live `tachyon-latest.json`.
- `sha256_checksum` is intentionally empty: 1.1.43 published no checksum, and the CLI skips verification when it is absent (`if (expectedChecksum)`).

## Applying it
The step runs in `publish_release` when `PUSH_JSON == 'true'` (same gate as the existing latest.json update). It takes effect on the next release publish; to fix the live manifest immediately, re-run the publish (or run the equivalent `aws s3 cp | jq | aws s3 cp` against `meta/tachyon-latest.json` + `meta/tachyon-stable.json`).

## Temporary
Marked clearly as a HACK in-code. Remove once a real 24.04 stable ships and the generation publishes it normally. Does **not** touch the git tags.