### PR TITLE
feat: [sc-140767] Ubuntu 24.04 build doesn't add build_date to manifest.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -562,6 +562,7 @@ jobs:
               platform: "qcm6490", board: "formfactor_dvt",
               os: "linux", distribution: "ubuntu",
               distribution_version: "24.04", distribution_variant: "ubuntu",
+              build_date: "2026-02-10T22:40:34.082161",
               artifacts: [{
                 artifact_url: ($base + "/" + $ver + "/" + . + "/tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver + ".zip"),
                 sha256_checksum: "", type: "release_image"


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/140767

Pinned version from #60  was missing build_date which broke the 20.04 builds
