### PR TITLE
versions.json: bump 24.04 base to image-25-a2357e9, kernel to particle5, bp-fw to 2.0.5

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -5,11 +5,15 @@
     // the pre-built region NON-HLOS images (nonhlos-em.img / nonhlos-na.img). Boot blobs are
     // TEST-signed; the composer RE-SIGNS them with the selectable key (see signing block).
     // Replaces the old 20.04 base (tachyon-release-builder) + U-Boot.
-    // 2.0.3 is the tagged release of the NON-HLOS-packaging PR (#7) — first release to ship
-    // nonhlos-em.img / nonhlos-na.img alongside QCM6490_bootbinaries + QCM6490_fw.
+    // 2.0.3 shipped the NON-HLOS packaging (#7) — nonhlos-em.img / nonhlos-na.img alongside
+    // QCM6490_bootbinaries + QCM6490_fw. Since then:
+    //   2.0.4 (#8) XBL: fix low-battery boot stuck in the UEFI charging loop.
+    //   2.0.5 (#9) qup: hand QUPV3_1_SE0 to HLOS as the 40pin header UART.
+    // 2.0.5 must be paired with kernel particle5 (PR #38): the BP releases the SE to HLOS and the
+    // kernel DT enables it. Downgrading either side alone leaves the 40pin header UART dead.
     "bp-fw": {
-      "version": "2.0.3",
-      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.3.zip"
+      "version": "2.0.5",
+      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.5.zip"
     },
 
     // The 24.04 base rootfs image (built by particle-iot/tachyon-ubuntu-24.04 via livecd-rootfs).
@@ -17,7 +21,7 @@
     // Variants: headless (== server) and desktop, both published.
     "particle-iot/tachyon-ubuntu-24.04": {
       "type": "git_release",
-      "param": "23-dfe823b"
+      "param": "25-a2357e9"
     },
 
     // Kernel input (single source of truth for the kernel line). Unlike main — where this was the
@@ -28,10 +32,10 @@
     // will fail.  <-- deb_version == env.PKG_linux_particle (see below)
     "particle-iot/tachyon-ubuntu-24.04-kernel": {
       "type": "s3_release",
-      "param": "stable-6.8.0-1058.59particle3",
+      "param": "stable-6.8.0-1058.59particle5",
       "abi": "1058",
       // keep this equal to env.PKG_linux_particle below
-      "deb_version": "6.8.0-1058.59+particle3",
+      "deb_version": "6.8.0-1058.59+particle5",
       "base_url": "https://linux-dist.particle.io/kernel/release"
     },
 
@@ -62,8 +66,8 @@
 
   "env": {
     // Kernel version pinned INSIDE the rootfs by the overlay. MUST equal the kernel source
-    // deb_version above (6.8.0-1058.59+particle3) and be installable on the base image's ABI.
-    "PKG_linux_particle": "6.8.0-1058.59+particle3",
+    // deb_version above (6.8.0-1058.59+particle5) and be installable on the base image's ABI.
+    "PKG_linux_particle": "6.8.0-1058.59+particle5",
 
     // Optional: URL to manually install kernel .deb (for unpublished PR builds).
     // Multiple URLs separated by @@@ for related packages (image + modules).


### PR DESCRIPTION
Update the 24.04 rootfs base from `23-dfe823b` to `25-a2357e9`, the kernel line from `particle3` to `particle5`, and the BP firmware from `2.0.3` to `2.0.5`.

## Changes

| source | from | to |
| --- | --- | --- |
| `bp-fw` | 2.0.3 | **2.0.5** |
| `particle-iot/tachyon-ubuntu-24.04` | 23-dfe823b | **25-a2357e9** |
| `particle-iot/tachyon-ubuntu-24.04-kernel` | stable-…particle3 | **stable-…particle5** |
| `deb_version` / `env.PKG_linux_particle` | +particle3 | **+particle5** |

ABI is unchanged (1058), and the three kernel touch-points are kept in lock-step as the file requires.

## bp-fw 2.0.5 and kernel particle5 must move together

BP #9 hands `QUPV3_1_SE0` to HLOS; kernel #38 enables it in DT as the 40pin header UART. Downgrading either side alone leaves that UART dead. The comment above the `bp-fw` block now records this, along with what 2.0.4 / 2.0.5 each shipped.

## What is in kernel particle5

particle5 rolls up four PRs merged since particle3, plus particle4:

- #40 `arm64: dts: qcom: sc7280: drop secure video SID from the base dtsi` — fixes the SMMU S2CR write abort that killed Venus hardware decode
- #39 `remoteproc: qcom_q6v5_pas: add CX/MX proxy votes for sc7280 cdsp` — fixes probabilistic cDSP boot timeout (0/2 → 7/7 cold boots)
- #38 `arm64: dts: qcom: enable 40pin header and syscon UARTs for tachyon` — pairs with bp-fw 2.0.5
- #37 `arm64: dts: qcom: enable micro SD slot for tachyon`
- #36 `ASoC: codecs: add Everest ES8388 I2C codec driver` (from particle4)

## Verification

All three download coordinates were resolved exactly as the Makefile builds them and checked with HTTP HEAD:

- bp-fw zip → 200, 225 MB
- kernel modules deb (`+` encoded as `%2B`) → 200, 141 MB
- base images via `tachyon-ci.particle.io/release/…` → headless 1.09 GB, desktop 2.71 GB, both 200

`versions.json` parses with the composer's own JSONC reader, and `deb_version == env.PKG_linux_particle` holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)