### PR TITLE
versions.json: move the 24.04 line to the current latest (base 25, kernel particle5, bp-fw 2.0.5, Particle debs)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -5,19 +5,27 @@
     // the pre-built region NON-HLOS images (nonhlos-em.img / nonhlos-na.img). Boot blobs are
     // TEST-signed; the composer RE-SIGNS them with the selectable key (see signing block).
     // Replaces the old 20.04 base (tachyon-release-builder) + U-Boot.
-    // 2.0.3 is the tagged release of the NON-HLOS-packaging PR (#7) — first release to ship
-    // nonhlos-em.img / nonhlos-na.img alongside QCM6490_bootbinaries + QCM6490_fw.
+    // 2.0.3 was the NON-HLOS-packaging release (#7) — first to ship nonhlos-em.img /
+    // nonhlos-na.img alongside QCM6490_bootbinaries + QCM6490_fw. Since then:
+    //   2.0.4 (#8) XBL: fix low-battery boot stuck in the UEFI charging loop.
+    //   2.0.5 (#9) qup: hand QUPV3_1_SE0 to HLOS as the 40pin header UART.
+    // 2.0.5 MUST move together with kernel particle5: BP #9 releases the SE to HLOS and kernel
+    // #38 enables it in DT. Bumping only one side leaves the 40pin header UART dead. The artifact
+    // layout is unchanged from 2.0.3 (same 519 entries, both nonhlos images), so the fetch/split
+    // in `make fetch_bp_fw` needs no changes.
     "bp-fw": {
-      "version": "2.0.3",
-      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.3.zip"
+      "version": "2.0.5",
+      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.5.zip"
     },
 
     // The 24.04 base rootfs image (built by particle-iot/tachyon-ubuntu-24.04 via livecd-rootfs).
     // Consumed as tachyon-ubuntu-24.04-<VARIANT>-image-<param>.img.xz from the release channel.
     // Variants: headless (== server) and desktop, both published.
+    // 25-a2357e9 was rebuilt against the latest particle kernel, so it already carries
+    // linux-particle 6.8.0-1058.59+particle5 — matching the kernel pinned below.
     "particle-iot/tachyon-ubuntu-24.04": {
       "type": "git_release",
-      "param": "23-dfe823b"
+      "param": "25-a2357e9"
     },
 
     // Kernel input (single source of truth for the kernel line). Unlike main — where this was the
@@ -28,10 +36,10 @@
     // will fail.  <-- deb_version == env.PKG_linux_particle (see below)
     "particle-iot/tachyon-ubuntu-24.04-kernel": {
       "type": "s3_release",
-      "param": "stable-6.8.0-1058.59particle3",
+      "param": "stable-6.8.0-1058.59particle5",
       "abi": "1058",
       // keep this equal to env.PKG_linux_particle below
-      "deb_version": "6.8.0-1058.59+particle3",
+      "deb_version": "6.8.0-1058.59+particle5",
       "base_url": "https://linux-dist.particle.io/kernel/release"
     },
 
@@ -62,23 +70,23 @@
 
   "env": {
     // Kernel version pinned INSIDE the rootfs by the overlay. MUST equal the kernel source
-    // deb_version above (6.8.0-1058.59+particle3) and be installable on the base image's ABI.
-    "PKG_linux_particle": "6.8.0-1058.59+particle3",
+    // deb_version above (6.8.0-1058.59+particle5) and be installable on the base image's ABI.
+    "PKG_linux_particle": "6.8.0-1058.59+particle5",
 
     // Optional: URL to manually install kernel .deb (for unpublished PR builds).
     // Multiple URLs separated by @@@ for related packages (image + modules).
 
     //This is the particle debian package
-    "PKG_particle_linux": "0.22.0-1",
+    "PKG_particle_linux": "0.25.0-1",
 
     //Version of the setup app being used
     "PKG_particle_tachyon_desktop_setup": "2.7.0",
 
     //Radio code (RIL)
-    "PKG_particle_tachyon_ril": "0.4.5-1",
+    "PKG_particle_tachyon_ril": "0.5.5-1",
 
     //The syscon package
-    "PKG_particle_tachyon_syscon": "1.0.20-2",
+    "PKG_particle_tachyon_syscon": "1.0.52-1",
 
     //Ubuntu 24.04 distribution version. ENV_ (not PKG_) on purpose: check-pinned-packages treats
     //every PKG_* as an apt package to install, but this is a plain config value. The overlay tool


### PR DESCRIPTION
Gives the 24.04 line the same treatment 20.04 just had in `tachyon-release-builder`: take every input the composer pins and move it to the newest published release. Branched from `main` (`2342615`, tag `1.2.3`).

## Changes — all of `versions.json`

| pin | from | to |
| --- | --- | --- |
| `bp-fw` | 2.0.3 | **2.0.5** |
| `particle-iot/tachyon-ubuntu-24.04` | 23-dfe823b | **25-a2357e9** |
| kernel `param` | `stable-…particle3` | **`stable-…particle5`** |
| kernel `deb_version` | `6.8.0-1058.59+particle3` | **`…+particle5`** |
| `env.PKG_linux_particle` | `6.8.0-1058.59+particle3` | **`…+particle5`** |
| `PKG_particle_linux` | 0.22.0-1 | **0.25.0-1** |
| `PKG_particle_tachyon_ril` | 0.4.5-1 | **0.5.5-1** |
| `PKG_particle_tachyon_syscon` | 1.0.20-2 | **1.0.52-1** |
| `PKG_particle_tachyon_desktop_setup` | 2.7.0 | 2.7.0 — *already latest* |

Every one of these is not just newer but the **newest** version published for arm64. The three Particle deb pins now match what 20.04 ships, so the two lines are back in step.

`ENV_UBUNTU_24_04_VERSION` stays `1.2` — it names the new-BP line the overlay gates on (`min: "1.2"`), not the release number.

## Why bp-fw and the kernel must move together

BP #9 hands `QUPV3_1_SE0` to HLOS; kernel #38 enables it in DT as the 40pin header UART. Bumping either side alone leaves that UART dead, so 2.0.5 and particle5 are a pair. The comment above the `bp-fw` block now records this along with what 2.0.4 and 2.0.5 each shipped.

- **2.0.4** (#8) — XBL: fix low-battery boot stuck in the UEFI charging loop. Tagged but never cut as a GitHub release, so it only reaches us via 2.0.5.
- **2.0.5** (#9) — qup: hand `QUPV3_1_SE0` to HLOS as the 40pin header UART.

## What kernel particle5 brings over particle3

- #40 `arm64: dts: qcom: sc7280: drop secure video SID from the base dtsi`
- #39 `remoteproc: qcom_q6v5_pas: add CX/MX proxy votes for sc7280 cdsp`
- #38 `arm64: dts: qcom: enable 40pin header and syscon UARTs for tachyon` — pairs with bp-fw 2.0.5
- #37 `arm64: dts: qcom: enable micro SD slot for tachyon`
- #36 `ASoC: codecs: add Everest ES8388 I2C codec driver` (via particle4)

Base `25-a2357e9` was rebuilt against the latest particle kernel, so the rootfs it ships already carries `+particle5`. ABI is unchanged at 1058 and the three kernel touch-points stay in lock-step as the file requires.

## Verification

`versions.json` parses with the composer's own JSONC reader, and `make print-config` resolves cleanly for both variants. Invariants asserted: `deb_version == env.PKG_linux_particle`, the kernel tag matches the deb version, and the ABI appears in it.

Every download coordinate was rebuilt exactly as the Makefile constructs it (including `+` → `%2B` on the kernel deb) and checked with HTTP HEAD:

| artifact | status | size |
| --- | --- | --- |
| `tachyon-bp-fw-2.0.5.zip` | 200 | 225 MB |
| `…-24.04-headless-image-25-a2357e9.img.xz` | 200 | 1.09 GB |
| `…-24.04-desktop-image-25-a2357e9.img.xz` | 200 | 2.71 GB |
| `linux-modules-6.8.0-1058-particle_…+particle5_arm64.deb` | 200 | 141 MB |

Each apt pin was checked against the arm64 `Packages` index of the suite it resolves from — `linux-particle` from `packages.particle.io/ubuntu noble-stable`, the rest from `packages.particle.io/debian latest` (which `add-particle-repo` adds and the stacks only narrow to `stable` *after* the pinned installs). All five present, all five the newest there.

The 2.0.5 artifact is layout-identical to 2.0.3 — same 519 entries, `nonhlos-em.img` and `nonhlos-na.img` both present at the same size, only the ADSP firmware blobs differ — so `make fetch_bp_fw` needs no changes. Verified by reading both zips' central directories over HTTP range requests.

No build was run: the composer builds ARM64 rootfs images under `chroot` on the self-hosted runner, so CI on this PR is the real test.

## Relationship to #64

#64 bumps base, kernel and bp-fw to the same three values and is still open. This PR is a superset — it adds the Particle deb pins, which is the part that brings 24.04 in line with the 20.04 update. If this one lands, #64 can be closed as covered; happy to go the other way and push just the deb pins onto #64 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA
