### PR TITLE
CI CONTROL - DO NOT MERGE: #65 with the three deb pins reverted

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -5,19 +5,27 @@
     // the pre-built region NON-HLOS images (nonhlos-em.img / nonhlos-na.img). Boot blobs are
     // TEST-signed; the composer RE-SIGNS them with the selectable key (see signing block).
     // Replaces the old 20.04 base (tachyon-release-builder) + U-Boot.
-    // 2.0.3 is the tagged release of the NON-HLOS-packaging PR (#7) — first release to ship
-    // nonhlos-em.img / nonhlos-na.img alongside QCM6490_bootbinaries + QCM6490_fw.
+    // 2.0.3 was the NON-HLOS-packaging release (#7) — first to ship nonhlos-em.img /
+    // nonhlos-na.img alongside QCM6490_bootbinaries + QCM6490_fw. Since then:
+    //   2.0.4 (#8) XBL: fix low-battery boot stuck in the UEFI charging loop.
+    //   2.0.5 (#9) qup: hand QUPV3_1_SE0 to HLOS as the 40pin header UART.
+    // 2.0.5 MUST move together with kernel particle5: BP #9 releases the SE to HLOS and kernel
+    // #38 enables it in DT. Bumping only one side leaves the 40pin header UART dead. The artifact
+    // layout is unchanged from 2.0.3 (same 519 entries, both nonhlos images), so the fetch/split
+    // in `make fetch_bp_fw` needs no changes.
     "bp-fw": {
-      "version": "2.0.3",
-      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.3.zip"
+      "version": "2.0.5",
+      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.5.zip"
     },
 
     // The 24.04 base rootfs image (built by particle-iot/tachyon-ubuntu-24.04 via livecd-rootfs).
     // Consumed as tachyon-ubuntu-24.04-<VARIANT>-image-<param>.img.xz from the release channel.
     // Variants: headless (== server) and desktop, both published.
+    // 25-a2357e9 was rebuilt against the latest particle kernel, so it already carries
+    // linux-particle 6.8.0-1058.59+particle5 — matching the kernel pinned below.
     "particle-iot/tachyon-ubuntu-24.04": {
       "type": "git_release",
-      "param": "23-dfe823b"
+      "param": "25-a2357e9"
     },
 
     // Kernel input (single source of truth for the kernel line). Unlike main — where this was the
@@ -28,10 +36,10 @@
     // will fail.  <-- deb_version == env.PKG_linux_particle (see below)
     "particle-iot/tachyon-ubuntu-24.04-kernel": {
       "type": "s3_release",
-      "param": "stable-6.8.0-1058.59particle3",
+      "param": "stable-6.8.0-1058.59particle5",
       "abi": "1058",
       // keep this equal to env.PKG_linux_particle below
-      "deb_version": "6.8.0-1058.59+particle3",
+      "deb_version": "6.8.0-1058.59+particle5",
       "base_url": "https://linux-dist.particle.io/kernel/release"
     },
 
@@ -62,23 +70,23 @@
 
   "env": {
     // Kernel version pinned INSIDE the rootfs by the overlay. MUST equal the kernel source
-    // deb_version above (6.8.0-1058.59+particle3) and be installable on the base image's ABI.
-    "PKG_linux_particle": "6.8.0-1058.59+particle3",
+    // deb_version above (6.8.0-1058.59+particle5) and be installable on the base image's ABI.
+    "PKG_linux_particle": "6.8.0-1058.59+particle5",
 
     // Optional: URL to manually install kernel .deb (for unpublished PR builds).
     // Multiple URLs separated by @@@ for related packages (image + modules).
 
     //This is the particle debian package
-    "PKG_particle_linux": "0.22.0-1",
+    "PKG_particle_linux": "0.25.0-1",
 
     //Version of the setup app being used
     "PKG_particle_tachyon_desktop_setup": "2.7.0",
 
     //Radio code (RIL)
-    "PKG_particle_tachyon_ril": "0.4.5-1",
+    "PKG_particle_tachyon_ril": "0.5.5-1",
 
     //The syscon package
-    "PKG_particle_tachyon_syscon": "1.0.20-2",
+    "PKG_particle_tachyon_syscon": "1.0.52-1",
 
     //Ubuntu 24.04 distribution version. ENV_ (not PKG_) on purpose: check-pinned-packages treats
     //every PKG_* as an apt package to install, but this is a plain config value. The overlay tool

--- a/versions.json
+++ b/versions.json
@@ -77,16 +77,16 @@
     // Multiple URLs separated by @@@ for related packages (image + modules).
 
     //This is the particle debian package
-    "PKG_particle_linux": "0.25.0-1",
+    "PKG_particle_linux": "0.22.0-1",
 
     //Version of the setup app being used
     "PKG_particle_tachyon_desktop_setup": "2.7.0",
 
     //Radio code (RIL)
-    "PKG_particle_tachyon_ril": "0.5.5-1",
+    "PKG_particle_tachyon_ril": "0.4.5-1",
 
     //The syscon package
-    "PKG_particle_tachyon_syscon": "1.0.52-1",
+    "PKG_particle_tachyon_syscon": "1.0.20-2",
 
     //Ubuntu 24.04 distribution version. ENV_ (not PKG_) on purpose: check-pinned-packages treats
     //every PKG_* as an apt package to install, but this is a plain config value. The overlay tool


### PR DESCRIPTION
**Draft, throwaway, do not merge or review.** This exists only to run CI.

## Purpose

PR #65 has now lost **11 of 11** image jobs across three runs, every time to `503 Service Unavailable` on Ubuntu `noble-updates` packages from `ec2.ports.ubuntu.com` during `apt-get upgrade`. #64 — same base, kernel and bp-fw, without the deb pins — went 4/4 green on 31 July. GitHub refuses to retry #64's run (`This workflow run cannot be retried`, four-week expiry), so that green result isn't a same-conditions control.

This branch is the missing control. It is `update/24.04-latest-release` with **three version strings** reverted and nothing else:

| pin | #65 | this branch |
| --- | --- | --- |
| `PKG_particle_linux` | 0.25.0-1 | 0.22.0-1 |
| `PKG_particle_tachyon_ril` | 0.5.5-1 | 0.4.5-1 |
| `PKG_particle_tachyon_syscon` | 1.0.52-1 | 1.0.20-2 |

Same base `25-a2357e9`, same kernel `particle5`, same bp-fw `2.0.5`. `git diff` against #65 is six lines, three of them `-`/`+` pairs.

## How to read the result

- **This fails too** → the deb pins are exonerated; the failure is the mirror.
- **This passes while #65 fails** → the pins are implicated and #65 needs rework.

## Prior evidence this is testing

The mechanism says the pins can't be involved: the failing `apt-get upgrade` transaction is `libssl3t64 curl krb5-* linux-firmware network-manager systemd-*` — all Ubuntu `noble-updates`, zero Particle packages — and those three debs aren't installed at that point in the stack, so `upgrade` has nothing of ours to act on. The 503 bursts also last 0.6s, 4.1s and 8.5s, which is a transient server-side condition, and a version pin cannot make a mirror return 503. This branch tests that reasoning rather than trusting it.

Retry hardening for the underlying fragility is separate, in `tachyon-overlays` #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA
