### PR TITLE
partition_ext: trim logdump 512MiB -> 64MiB (20.04 parity)

### DIFF
--- a/scripts/assemble/config/partition_ext.xml
+++ b/scripts/assemble/config/partition_ext.xml
@@ -103,7 +103,7 @@
         <partition label="toolsfv" 			size_in_kb="1024" 		type="97745ABA-135A-44C3-9ADC-05616173C24C" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="tools.fv"/>
         <partition label="logfs" 			size_in_kb="8192" 		type="BC0330EB-3410-4951-A617-03898DBE3372" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
         <partition label="quantumsdk" 		size_in_kb="40960" 		type="AA9A5C4C-4F1F-7D3A-014A-22BD33BF7191" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
-        <partition label="logdump" 			size_in_kb="524288" 	type="5AF80809-AABB-4943-9168-CDFC38742598" readonly="false" bootable="false" 	system="true" dontautomount="true" filename=""/>
+        <partition label="logdump" 			size_in_kb="65536" 	type="5AF80809-AABB-4943-9168-CDFC38742598" readonly="false" bootable="false" 	system="true" dontautomount="true" filename=""/>
         <partition label="secdata" 			size_in_kb="25" 		type="76CFC7EF-039D-4E2C-B81E-4DD8C2CB2A93" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/> 
         <partition label="quantumfv" 		size_in_kb="512" 		type="80C23C26-C3F9-4A19-BB38-1E457DACEB09" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
         <partition label="catecontentfv" 	size_in_kb="1024" 		type="E12D830B-7F62-4F0B-B48A-8178C5BF3AC1" bootable="false" readonly="true"/>


### PR DESCRIPTION
## What

One attribute in `scripts/assemble/config/partition_ext.xml`:

```diff
-<partition label="logdump" size_in_kb="524288" .../>
+<partition label="logdump" size_in_kb="65536"  .../>
```

## Why

`logdump` was 512 MiB — **40% of the whole firmware LUN**, and the single largest
entry on LUN 4, bigger than every A/B pair except the modem image itself. For
comparison, of LUN 4's 1265.6 MiB:

| | size |
|---|---|
| all 18 duplicated A/B pairs | ~591 MiB |
| single-copy entries | ~675 MiB |
| — of which `logdump` alone | **512 MiB** |

The 20.04 line sizes the same partition at 65536 KB (64 MiB). This restores parity.

## Verification

`partition_ext.xml` is the only hand-authored partition definition — every
`rawprogram*.xml`, `patch*.xml` and `gpt_*.bin` is generated from it by
`scripts/assemble/ptool.py` on each build (`make_factory_img.sh`). So I ran ptool
over both versions and diffed the generated tables:

```
before:  logdump@184167+131072   last_parti@323986   (1265.6 MiB)
after:   logdump@184167+16384    last_parti@209298   ( 817.6 MiB)
```

- Frees **448 MiB** on LUN 4.
- Only the four entries behind `logdump` shift (`secdata`, `quantumfv`, `catecontentfv`, `vm-data`).
- `core_nhlos_a` stays at sector 31770; everything ahead of `logdump` is byte-identical.
- The edit is scoped to the `logdump` label deliberately: `efi` is *also*
  `size_in_kb="524288"`, and moving the ESP would have been a real bug.

## What this does NOT fix

To set expectations: this does **not** make the image flashable on a board
carrying the 20.04 LUN geometry. `core_nhlos_a` starts at sector 31770 (129.9 MiB)
on a 128 MiB LUN 4 and is itself 170 MiB, so it cannot fit regardless of what
shrinks behind it — shrinking a partition can't move an earlier one. That is a
geometry/provisioning problem tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA