### PR TITLE
partition_ext: move the firmware set to LUN 6, keep NV in place

### DIFF
--- a/scripts/assemble/config/partition_ext.xml
+++ b/scripts/assemble/config/partition_ext.xml
@@ -47,8 +47,31 @@
 		<partition label="ddr_b" 			size_in_kb="1024" 		type="325DEF02-1305-44A3-AA8D-AC82FEBE220E" 									system="true" dontautomount="true" filename=""/>
         <partition label="last_parti" 		size_in_kb="0" 			type="00000000-0000-0000-0000-000000000000" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="" />
     </physical_partition>
-
-   <!-- This is LUN 4 - Firmware LUN" -->
+   <!-- This is LUN 4 - kept 20.04-compatible (128 MiB on already-provisioned
+        devices); the firmware set has been moved to LUN 6 so it fits without
+        re-provisioning. Mirrors the 20.04 LUN 4 so uefivarstore is preserved. -->
+     <physical_partition>
+        <partition label="abl_a" 			size_in_kb="1024" 		type="BD6928A1-4CE0-A038-4F3A-1495E3EDDFFB" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
+        <partition label="abl_b" 			size_in_kb="1024" 		type="77036CD4-03D5-42BB-8ED1-37E5A88BAA34" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
+        <partition label="uefivarstore" 	size_in_kb="512" 		type="165BD6BC-9250-4AC8-95A7-A93F4A440066" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
+        <partition label="last_parti" 		size_in_kb="0" 			type="00000000-0000-0000-0000-000000000000" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="" />
+     </physical_partition>
+    <!-- This is LUN 5 - Protected Read-write LUN" -->
+    <!-- QCOM development requirement: Ensure all partitions in LUN5 is a MULTIPLE OF 128K -->
+    <!-- Ordered and sized to reproduce the offsets already on provisioned
+         devices (fsc@32, fsg@64, modemst1@1088, modemst2@2112, nvdata1@3136,
+         nvdata2@3520) so modem NV survives a flash in either direction. -->
+    <physical_partition>
+        <partition label="ALIGN_TO_128K_2" 	size_in_kb="104" 		type="FDE1604B-D68B-4BD4-973D-962AE7A1ED88" bootable="false" readonly="true" />
+        <partition label="fsc" 				size_in_kb="128" 		type="57B90A16-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+        <partition label="fsg" 				size_in_kb="4096" 		type="638FF8E2-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
+        <partition label="modemst1" 		size_in_kb="4096" 		type="EBBEADAF-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+        <partition label="modemst2" 		size_in_kb="4096" 		type="0A288B1F-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+        <partition label="nvdata1" 			size_in_kb="1536" 		type="C733EFB2-31D6-4175-8756-D12BF1F5271D" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+        <partition label="nvdata2" 			size_in_kb="1536" 		type="D47E62B3-EB9E-48E3-BA8A-57A64ACE2D3F" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
+        <partition label="last_parti" 		size_in_kb="0" 			type="00000000-0000-0000-0000-000000000000" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="" />
+    </physical_partition>
+   <!-- This is LUN 6 - Firmware LUN (moved from LUN 4: 24.04 needs ~818 MiB here and LUN 4 is only 128 MiB on provisioned devices; LUN 6 is 1792 MiB) -->
      <physical_partition>	
 		<!-- These are the 'A' partition's needed for the A/B boot/ota update feature. A and B partitions must have differrent GUID's.  -->
         <partition label="aop_a" 			size_in_kb="512" 		type="D69E90A5-4CAB-0071-F6DF-AB977F141A7F" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="aop.mbn"/>
@@ -110,17 +133,4 @@
 		<partition label="vm-data" 			size_in_kb="33424" 		type="21ADB864-C9E7-4C76-BE68-568E20C58439" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
 		<partition label="last_parti" 		size_in_kb="0" 			type="00000000-0000-0000-0000-000000000000" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="" />
     </physical_partition>	
-		
-    <!-- This is LUN 5 - Protected Read-write LUN" -->	
-    <!-- QCOM development requirement: Ensure all partitions in 	LUN5 iS A MULTIPLE OF 128K -->
-			
-    <physical_partition>	
-        <partition label="modemst1" 		size_in_kb="4096" 		type="EBBEADAF-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
-        <partition label="modemst2" 		size_in_kb="4096" 		type="0A288B1F-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
-        <partition label="fsg" 				size_in_kb="4096" 		type="638FF8E2-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="true" 	system="true" dontautomount="true" filename=""/>
-        <partition label="fsc" 				size_in_kb="128" 		type="57B90A16-22C9-E33B-8F5D-0E81686A68CB" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
-        <partition label="nvdata1" 			size_in_kb="4096" 		type="C733EFB2-31D6-4175-8756-D12BF1F5271D" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
-        <partition label="nvdata2" 			size_in_kb="4096" 		type="D47E62B3-EB9E-48E3-BA8A-57A64ACE2D3F" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
-        <partition label="last_parti" 		size_in_kb="0" 			type="00000000-0000-0000-0000-000000000000" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="" />
-    </physical_partition>
 </configuration>


### PR DESCRIPTION
## The bug

24.04 `1.2.x` cannot be flashed onto any board carrying the 20.04 UFS geometry.
Reproduced four times — two boards, two hosts, and once with `particle flash --tachyon`
invoked directly with embroid out of the loop. Every run died at the identical point:

```
status=Start flashing module, module=core_nhlos_a, sectors_total=43520, sectors_done=1280
[ERROR] bulk write failed: Operation timed out
[ERROR] USB write failed for data chunk
[ERROR] firehose_run failed
```

**It's a LUN boundary overrun, not a size problem.** 20.04 provisions LUN 4 at
`131072 KB` = **32768 sectors** (4096 B sectors). The 24.04 layout starts writing
`core_nhlos_a` at sector **31770** — so it begins ~1 MiB before the end of a LUN it
needs 43520 sectors of. The device stops responding and the firehose surfaces a USB
bulk-write timeout instead of a clean size error. Even a tiny modem image would fail,
because it starts past the edge.

Confirmed by reading all seven GPTs off a real board with qdl:

| LUN | provisioned | 24.04 needs |
|---|---|---|
| 4 | **32,768 sectors** (128 MiB) | 323,986 |
| 6 | **458,752 sectors** (1792 MiB) | — unused by 24.04 |

## The change

- Firmware set moved **LUN 4 → LUN 6**, where it fits with room to spare.
- LUN 4 kept 20.04-compatible (`abl_a`/`abl_b`/`uefivarstore`), so `uefivarstore` survives.
- **LUN 5 reordered so NV lands on the sectors provisioned devices already use:**
  `fsc@32`, `fsg@64`, `modemst1@1088`, `modemst2@2112`, `nvdata1@3136+384`, `nvdata2@3520+384`.

That last point is the one that matters most: NV becomes byte-compatible with the 20.04
layout, so flashing in **either direction preserves modem calibration** — no
backup/restore, no re-provisioning, no factory image.

## Verification

`partition_ext.xml` is the only hand-authored table; ptool regenerates all
`rawprogram*`/`patch*`/`gpt_*` on each build. Generated extents vs the real device:

```
LUN 1   2,064 /   2,069      LUN 4     646 /  32,768
LUN 2   2,064 /   2,069      LUN 5   3,904 /  36,864
LUN 3     832 /     837      LUN 6 323,986 / 458,752
```

Then flashed end-to-end on head2 through the **ordinary** `particle flash --tachyon`
path — no `--mode factory`, no provisioning:

- **36 modules, 0 errors, 284 s**
- `core_nhlos_a` wrote all 43520 sectors at 29 MB/s
- `91 patches applied`, `partition 1 is now bootable`, `OS Download complete`
- Booted to `Ubuntu 24.04.4 LTS ubuntu ttyMSM0` / login prompt
- `lsblk`: LUN 6 (`sdg`) 1.8 G carrying the firmware set, LUN 4 (`sde`) still holding the
  untouched 20.04 `abl_a`/`abl_b`/`uefivarstore`, `system` grown to 56.6 G
- **`nvdata1`/`nvdata2` still 1.5 MiB** (the 20.04 sizes) — NV preserved in place

## Notes

- Independent of the `logdump` trim in #67. Both were applied together while testing, but
  this fits on its own (323,986 < 458,752), so the two can merge in either order.
- Two unrelated pre-existing bugs surfaced during this and are fixed separately in
  tachyon-overlays: `fix-qcom-modem` hardcodes `/dev/sdf8` for `/persist` (a 20.04 path;
  24.04 puts persist on LUN 0), and its unit waits on `dev-sdf8.device`/`dev-sdg1.device`.
- Worth a look separately: `tachyon-firmware` is wired into
  `stacks/ubuntu-common-24.04.json` but is **not installed** in the shipped image, so
  `libql_ril.so` is missing and `particle-tachyon-rild` exits 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA