### PR TITLE
versions: scope the desktop-setup pin to desktop builds only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,21 @@ VERSIONS_FILE ?= versions.json
 _SRC      = $(shell python3 -c "import json,re;t=re.sub(r'^\s*//.*$$','',open('$(VERSIONS_FILE)').read(),flags=re.MULTILINE);print(json.loads(t)['sources'].get('$(1)',{}).get('$(2)',''))" 2>/dev/null)
 _ENV_JSON = $(shell python3 -c "import json,re;t=re.sub(r'^\s*//.*$$','',open('$(VERSIONS_FILE)').read(),flags=re.MULTILINE);e=json.loads(t).get('env',{});print(','.join(f'{k}={v}' for k,v in e.items()))" 2>/dev/null)
 _SIGN     = $(shell python3 -c "import json,re;t=re.sub(r'^\s*//.*$$','',open('$(VERSIONS_FILE)').read(),flags=re.MULTILINE);print(json.loads(t).get('signing',{}).get('$(1)',''))" 2>/dev/null)
+# Same as _ENV_JSON but for an arbitrary top-level object, so a build can carry
+# variant-only pins (env_desktop / env_headless) instead of forcing every PKG_*
+# onto every variant. Missing key -> empty.
+_ENV_JSON_KEY = $(shell python3 -c "import json,re;t=re.sub(r'^\s*//.*$$','',open('$(VERSIONS_FILE)').read(),flags=re.MULTILINE);e=json.loads(t).get('$(1)',{});print(','.join(f'{k}={v}' for k,v in e.items()))" 2>/dev/null)
 
 JSON_BASE24_PARAM       := $(call _SRC,particle-iot/tachyon-ubuntu-24.04,param)
 JSON_OVERLAYS_PARAM     := $(call _SRC,particle-iot/tachyon-overlay,param)
 JSON_OVERLAY_TOOL_PARAM := $(call _SRC,particle-iot/tachyon-overlay-tool,param)
 ENV_FROM_JSON           := $(_ENV_JSON)
+ENV_FROM_JSON_VARIANT   := $(call _ENV_JSON_KEY,env_$(INPUT_VARIANT))
+# Fold the variant-only pins in after the shared ones so they can add (or override)
+# entries for this build only. Keeps particle-tachyon-desktop-setup off headless.
+ifneq ($(strip $(ENV_FROM_JSON_VARIANT)),)
+  ENV_FROM_JSON := $(if $(strip $(ENV_FROM_JSON)),$(ENV_FROM_JSON)$(comma),)$(ENV_FROM_JSON_VARIANT)
+endif
 
 ifneq ($(strip $(JSON_BASE24_PARAM)),)
   INPUT_BASE_24_04_VERSION ?= $(JSON_BASE24_PARAM)

--- a/versions.json
+++ b/versions.json
@@ -80,8 +80,6 @@
     "PKG_particle_linux": "0.25.0-1",
 
     //Version of the setup app being used
-    "PKG_particle_tachyon_desktop_setup": "2.7.0",
-
     //Radio code (RIL)
     "PKG_particle_tachyon_ril": "0.5.5-1",
 
@@ -96,5 +94,13 @@
 
     //version used in the debian file to pin the version down
     "PIN_PRIORITY": "900"
+  },
+
+  // Variant-only pins. Folded into the overlay env by the Makefile as
+  // env_<INPUT_VARIANT>, so these apply to that variant alone.
+  // particle-tachyon-desktop-setup lived in the shared env, which meant the pin
+  // machinery installed it on headless too.
+  "env_desktop": {
+    "PKG_particle_tachyon_desktop_setup": "2.7.0"
   }
 }

--- a/versions.json
+++ b/versions.json
@@ -79,7 +79,6 @@
     //This is the particle debian package
     "PKG_particle_linux": "0.25.0-1",
 
-    //Version of the setup app being used
     //Radio code (RIL)
     "PKG_particle_tachyon_ril": "0.5.5-1",
 
@@ -101,6 +100,7 @@
   // particle-tachyon-desktop-setup lived in the shared env, which meant the pin
   // machinery installed it on headless too.
   "env_desktop": {
+    //Version of the setup app being used
     "PKG_particle_tachyon_desktop_setup": "2.7.0"
   }
 }


### PR DESCRIPTION
## The bug

`particle-tachyon-desktop-setup` **2.7.0 is installed on headless images.** Confirmed on a flashed headless board:

```
dpkg-query -W particle-tachyon-desktop-setup  ->  2.7.0
systemctl get-default                         ->  graphical.target
```

No overlay puts it there. The `particle-tachyon` metapackage only depends on `particle-linux`, `particle-tachyon-ril`, `particle-tachyon-syscon`. The route is this repo: the pin lived in the shared `env` block, `_ENV_JSON` flattens that block wholesale into the overlay env, and the pin machinery installs **every** `PKG_*` it's handed — regardless of variant.

## The change

A variant-scoped env block. New `_ENV_JSON_KEY` helper reads `env_<INPUT_VARIANT>` and folds it in *after* the shared entries, so a variant can add or override pins for itself alone. `PKG_particle_tachyon_desktop_setup` moves to `env_desktop`.

Verified by resolving `ENV_FROM_JSON` for both variants:

```
INPUT_VARIANT=desktop   …,PIN_PRIORITY=900,PKG_particle_tachyon_desktop_setup=2.7.0
INPUT_VARIANT=headless  …,PIN_PRIORITY=900
```

## Why keep the pin rather than drop it

The simpler fix would be deleting the pin and letting `add-desktop-setup` install the package on desktop. That silently regresses: **2.7.0 exists only in the `latest` suite** —

```
debian/stable  1.0.0 1.0.1 2.0.0 … 2.5.2 2.6.1
debian/latest  2.4.0 2.4.1 … 2.6.1 2.7.0
```

— so an unpinned install landing after `change-particle-repo-to-stable` would quietly take ≤2.6.1. Keeping the pin preserves both the version and reproducibility.

## Related

Pairs with **particle-iot/tachyon-overlays#33**, which adds `add-desktop-setup` (plus the rest of the missing desktop app set) to the 24.04 desktop stack and adds `set-headless-default-target` for the `graphical.target` half of this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA