### PR TITLE
compose_24_04: gate the shipped rootfs on content, not just ext4 metadata

### DIFF
--- a/compose_24_04.sh
+++ b/compose_24_04.sh
@@ -73,6 +73,70 @@ fsck_gate(){
   [ "$rc" -eq 0 ] || echo "WARN: e2fsck corrected metadata in $img (stage=$stage, rc=$rc) — investigate the build step that produced it"
 }
 
+# Verify the CONTENT invariants that e2fsck cannot see.
+#
+# e2fsck only proves the metadata is self-consistent. It passes -- cleanly, exit 0 -- on an
+# image whose most recent writes were silently dropped, because ext4 commits its journal every
+# few seconds and the replay makes what survived look perfect. That is exactly what shipped in
+# 1.2.8: the filesystem was pristine by e2fsck, yet it carried 9 files from the last dpkg
+# transaction still under their *.dpkg-new names (while dpkg's own status file, already
+# flushed, recorded the packages as installed), an unreplayed dpkg journal, and an
+# /etc/particle/distro_versions.json containing v4l-utils' deb control blob instead of its
+# JSON -- which then broke board detection and the syscon MCU upgrade on the device.
+#
+# These three checks are the fingerprint of that loss, and each one alone would have caught it.
+content_gate(){
+  local img="$1" stage="$2" mnt rc=0 stray journal dv
+  echo "INFO: content gate ($stage): $img"
+  mnt="$(mktemp -d)"
+  if ! sudo mount -o ro,loop "$img" "$mnt"; then
+    echo "ERROR: content gate cannot mount $img (stage=$stage)" >&2
+    rmdir "$mnt" 2>/dev/null || true
+    exit 1
+  fi
+
+  # 1) Unfinished dpkg file renames. dpkg unpacks to <path>.dpkg-new then renames into place;
+  #    survivors mean the rename never reached the image.
+  stray="$(sudo find "$mnt" -xdev \( -name '*.dpkg-new' -o -name '*.dpkg-tmp' \) -printf '%P\n' 2>/dev/null || true)"
+  if [ -n "$stray" ]; then
+    echo "ERROR: unfinished dpkg renames in $img (stage=$stage):" >&2
+    printf '%s\n' "$stray" | sed 's|^|    /|' >&2
+    rc=1
+  fi
+
+  # 2) dpkg's journal must be empty. Any entry means a transaction did not complete, and the
+  #    device inherits a dpkg that refuses to run until the journal is replayed.
+  journal="$(sudo find "$mnt/var/lib/dpkg/updates" -maxdepth 1 -type f -printf '%P\n' 2>/dev/null || true)"
+  if [ -n "$journal" ]; then
+    echo "ERROR: unreplayed dpkg journal in $img (stage=$stage): $(printf '%s ' $journal)" >&2
+    rc=1
+  fi
+
+  # 3) The version file must be the JSON add-particle-version generated, with the keys the
+  #    device actually reads (syscon reads .distro.board to decide MCU upgrades).
+  dv="$mnt/etc/particle/distro_versions.json"
+  if ! sudo test -f "$dv"; then
+    echo "ERROR: $img is missing /etc/particle/distro_versions.json (stage=$stage)" >&2
+    rc=1
+  elif ! sudo cat "$dv" | python3 -c 'import json,sys; d=json.load(sys.stdin); [d["distro"][k] for k in ("board","variant","version","stack")]' >/dev/null 2>&1; then
+    echo "ERROR: /etc/particle/distro_versions.json is not the expected JSON (stage=$stage). First 300 bytes:" >&2
+    sudo head -c 300 "$dv" 2>/dev/null | sed 's|^|    |' >&2 || true
+    rc=1
+  fi
+
+  sudo umount "$mnt" 2>/dev/null || true
+  rmdir "$mnt" 2>/dev/null || true
+
+  if [ "$rc" -ne 0 ]; then
+    echo "ERROR: content gate failed for $img (stage=$stage) — refusing to ship." >&2
+    echo "       This is the signature of overlay writes lost before the image was persisted;" >&2
+    echo "       check the overlay tool's unmount step (a swallowed umount failure means the" >&2
+    echo "       image was copied back while still mounted)." >&2
+    exit 1
+  fi
+  echo "OK: content gate passed ($stage): $img"
+}
+
 mkdir -p "$OUT"
 work="$(mktemp -d)"
 
@@ -153,6 +217,8 @@ ENV_OPT=(); [ -n "$OVERLAY_ENV" ] && ENV_OPT=(-e "$OVERLAY_ENV")
 # Final gate: the overlay tool dd-roundtrips and re-mounts the fs; verify the SHIPPED image is
 # metadata-consistent (superblock counts == group descriptors) before it gets assembled/flashed.
 fsck_gate "$ROOTFS" post-overlay
+# e2fsck above proves the metadata; this proves the overlay's writes actually landed.
+content_gate "$ROOTFS" post-overlay
 echo "OK: overlay applied to $ROOTFS"
 
 # ---- 4) dtb.img + nonhlos-<variant>.img -------------------------------------


### PR DESCRIPTION
## Why the existing gate wasn't enough

`fsck_gate` proves the filesystem's metadata is self-consistent. It cannot prove the overlay's writes actually landed — and shipped 1.2.8 and 1.2.9 are the proof: `e2fsck -fn` returns **exit 0 and "clean"** on both, because ext4 commits its journal every few seconds and the replay makes whatever survived look perfect.

Both images went out. What they actually contain:

| | 1.2.8 NA headless | 1.2.9 NA headless |
|---|---|---|
| `e2fsck -fn` | clean, exit 0 | clean, exit 0 |
| stray `*.dpkg-new` | 9 (v4l-utils) | 12 (v4l-utils **+ x11 app-defaults**) |
| dpkg journal | `0000`, `0001`, `0007` | `0000` = **59 MB of binary**, `0007` |
| `distro_versions.json` | v4l-utils' deb **control blob** | **`/etc/particle` absent entirely** |

On device this cost us: `dpkg` refusing to run (unreplayed journal), and `particle-tachyon-syscon` reading `.distro.board` as null and aborting the MCU upgrade with `Unknown board`.

## The gate

`content_gate` runs after the overlay stage and checks three invariants that this class of failure always violates:

1. **No `*.dpkg-new` / `*.dpkg-tmp` anywhere.** `dpkg` unpacks to `<path>.dpkg-new` then renames into place; survivors mean the rename never reached the image.
2. **`/var/lib/dpkg/updates` is empty.** Any entry means a transaction didn't complete, and the device inherits a `dpkg` that refuses to run until the journal is replayed.
3. **`/etc/particle/distro_versions.json` parses as JSON** and carries the keys the device actually reads (`.distro.board` gates the syscon MCU upgrade).

Failures print the offending paths and name the likely cause, so a recurrence is diagnosed rather than re-investigated from scratch.

## Testing

Run against real artifacts:

- **shipped 1.2.8 `rootfs.ext4` → rejected**, all three checks firing
- **shipped 1.2.9 `rootfs.ext4` → rejected**, all three checks firing (different files — 12 strays, missing `/etc/particle`)
- clean synthetic image with a well-formed version file → **passed**
- that same clean image with a single planted `.dpkg-new` → **rejected**

Each check independently rejects the real defective builds.

## Root cause

Fixed in particle-iot/tachyon-overlay-tool#5, which stops swallowing `umount` failures before persisting the image. **That should land first** — this repo tracks the tool's `main`, so the cause is fixed on the next build with no version bump, and this gate then has nothing to trip on.

This gate is the backstop, not the fix: it fails the build for any cause of the same class, whatever the mechanism.

## Note for a follow-up

`versions.json` carries entries for both `particle-iot/tachyon-overlay` and `particle-iot/tachyon-overlay-tool`. Those are the **same** repository — `tachyon-overlay` is an old name that GitHub redirects — and there is no entry for `particle-iot/tachyon-overlays` (the overlay *content*). Worth tidying separately; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA
