### PR TITLE
versions: particle-linux 0.25.0-1 -> 0.25.1-1 (D-Bus connection leak fix)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -86,7 +86,7 @@
     // Multiple URLs separated by @@@ for related packages (image + modules).
 
     //This is the particle debian package
-    "PKG_particle_linux": "0.25.0-1",
+    "PKG_particle_linux": "0.25.1-1",
 
     //Radio code (RIL)
     "PKG_particle_tachyon_ril": "0.5.5-1",


### PR DESCRIPTION
Picks up `particle-linux` **0.25.1-1**, which fixes a D-Bus connection leak in `particled`.

```diff
-    "PKG_particle_linux": "0.25.0-1",
+    "PKG_particle_linux": "0.25.1-1",
```

## What 0.25.1 fixes

`InternetState` created a new system-bus connection on every forced connectivity check and never released it. That check runs on a 60 s timer, so `particled` leaked one connection per minute until it hit `dbus-daemon`'s `max_connections_per_user` (256 by default) — at which point **the entire UID is locked out of the system bus**, not just `particled`.

Observed on head2-tachyon: system-wide D-Bus sockets sat at **261**, and `mmcli` could not talk to ModemManager at all. Stopping `particled` dropped it to **14** and `mmcli` recovered immediately — which is what identified the leak.

The fix wraps both per-call bus creations in `try/finally` with `bus.disconnect()`. The long-lived bus in `listenForNmState()` is deliberately left alone; it is meant to persist.

## Release status

- `particle-linux` 0.25.1 tagged for the **`latest`** channel only — no `stable-0.25.x` tag was cut, so `stable` is unaffected.
- Verified published: `particle-linux 0.25.1-1` is present in `https://packages.particle.io/debian/dists/latest/main/binary-arm64/Packages`.

## Independent of the build fixes

This is unrelated to particle-iot/tachyon-composer#71 and particle-iot/tachyon-overlay-tool#5 and can land in any order. Worth noting though: until #5 lands, **any** build may silently drop arbitrary files, so a build cut to validate this bump could fail for reasons that have nothing to do with the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA
