### PR TITLE
versions: kernel 6.8.0-1058.59+particle6 + base image 26-0519f5b

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -21,11 +21,11 @@
     // The 24.04 base rootfs image (built by particle-iot/tachyon-ubuntu-24.04 via livecd-rootfs).
     // Consumed as tachyon-ubuntu-24.04-<VARIANT>-image-<param>.img.xz from the release channel.
     // Variants: headless (== server) and desktop, both published.
-    // 25-a2357e9 was rebuilt against the latest particle kernel, so it already carries
-    // linux-particle 6.8.0-1058.59+particle5 — matching the kernel pinned below.
+    // 26-0519f5b was rebuilt against the latest particle kernel, so it already carries
+    // linux-particle 6.8.0-1058.59+particle6 — matching the kernel pinned below.
     "particle-iot/tachyon-ubuntu-24.04": {
       "type": "git_release",
-      "param": "25-a2357e9"
+      "param": "26-0519f5b"
     },
 
     // Kernel input (single source of truth for the kernel line). Unlike main — where this was the
@@ -36,10 +36,10 @@
     // will fail.  <-- deb_version == env.PKG_linux_particle (see below)
     "particle-iot/tachyon-ubuntu-24.04-kernel": {
       "type": "s3_release",
-      "param": "stable-6.8.0-1058.59particle5",
+      "param": "stable-6.8.0-1058.59particle6",
       "abi": "1058",
       // keep this equal to env.PKG_linux_particle below
-      "deb_version": "6.8.0-1058.59+particle5",
+      "deb_version": "6.8.0-1058.59+particle6",
       "base_url": "https://linux-dist.particle.io/kernel/release"
     },
 
@@ -79,8 +79,8 @@
 
   "env": {
     // Kernel version pinned INSIDE the rootfs by the overlay. MUST equal the kernel source
-    // deb_version above (6.8.0-1058.59+particle5) and be installable on the base image's ABI.
-    "PKG_linux_particle": "6.8.0-1058.59+particle5",
+    // deb_version above (6.8.0-1058.59+particle6) and be installable on the base image's ABI.
+    "PKG_linux_particle": "6.8.0-1058.59+particle6",
 
     // Optional: URL to manually install kernel .deb (for unpublished PR builds).
     // Multiple URLs separated by @@@ for related packages (image + modules).


### PR DESCRIPTION
Moves the 24.04 line onto the new particle6 kernel and the base image rebuilt against it.

## What changed

Four pins that `versions.json` itself documents as having to move together — the kernel
`deb_version` must equal `env.PKG_linux_particle`, and both must match the kernel baked into
the base image, or `check-pinned-packages` fails:

| field | from | to |
|---|---|---|
| `tachyon-ubuntu-24.04.param` | `25-a2357e9` | `26-0519f5b` |
| kernel `.param` | `stable-6.8.0-1058.59particle5` | `stable-6.8.0-1058.59particle6` |
| kernel `.deb_version` | `6.8.0-1058.59+particle5` | `6.8.0-1058.59+particle6` |
| `env.PKG_linux_particle` | `6.8.0-1058.59+particle5` | `6.8.0-1058.59+particle6` |

ABI is unchanged (`1058`), so nothing ABI-coupled moves. The two comments naming the old
versions were updated too, since they document the lock-step rule and stale text there is
actively misleading.

## What this brings in

`media: iris: switch sc7280 to the v6.19 driver with Gen2 firmware`
(tachyon-ubuntu-24.04-kernel#42), plus base image `image-26-0519f5b` rebuilt against it.

## Pre-flight checks already done

- Both particle6 debs return HTTP 206 at the composer's fetch path
  `kernel/release/stable-6.8.0-1058.59particle6/`, same layout as particle5, so
  `make fetch` and the `qcm6490-tachyon.dtb` extraction need no changes.
- `image-26-0519f5b` published 08:12Z; both headless and desktop `.img.xz` live on the CDN.
- The base image was built **after** particle6 reached `noble-stable`, so
  `--linux-flavours particle` resolved to particle6 rather than silently re-baking particle5.

## Kernel validation

Full `vpu-iris` matrix on head2: **PASS 104 / FAIL 7 / CRASH 0 / NOT RUN 22**. Diffed per-test
against the 260827 baseline: no status changes in either direction, the same 7 pre-existing
failures with identical messages, and one test (`neg-format`) that isn't in the baseline at all
now passing.

Provenance: the published stable debs are **not** byte-identical to the build-374 debs validated
on hardware, because these kernel builds aren't reproducible. The source is identical — comparing
the tested commit `d1d83902c` against the stable tag `857f6a66`, the only differing file in the
whole tree is `debian.qcom/changelog`, and both modules carry the same
`srcversion=85C2D79A1D5FD6336C00ABC`. So: same source, different build. The stable binary itself
has not been run on hardware — which is what testing this PR's prerelease image covers.
