### PR TITLE
versions: particle-tachyon-ril 0.5.5-1 -> 0.6.0-1 (fixes libql_ril.so boot failure)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -89,7 +89,7 @@
     "PKG_particle_linux": "0.25.1-1",
 
     //Radio code (RIL)
-    "PKG_particle_tachyon_ril": "0.5.5-1",
+    "PKG_particle_tachyon_ril": "0.6.0-1",
 
     //The syscon package
     "PKG_particle_tachyon_syscon": "1.0.52-1",


### PR DESCRIPTION
Bumps `particle-tachyon-ril` from `0.5.5-1` to `0.6.0-1`.

## Why this matters — 0.5.5-1 cannot run

On a device flashed with the current pin, both services fail at boot:

```
particle-tachyon-rild.service: Main process exited, code=exited, status=127
particle-tachyon-gnss.service: Main process exited, code=exited, status=127

/usr/bin/particle-tachyon-rild: error while loading shared libraries:
    libql_ril.so: cannot open shared object file: No such file or directory
```

`0.5.5-1` links `libql_ril.so`, but the package declares only
`libc6, libsqlite3-0, libsystemd0, socat` and ships **no** shared library —
and nothing else on the image provides it (`find / -name 'libql_ril*'` is empty).
Because the dependency is undeclared, `apt-get check` reports the system as clean,
so no existing gate catches it.

`0.6.0-1` fixes exactly this: the library is renamed and, crucially, **shipped**.

| | 0.5.5-1 | 0.6.0-1 |
|---|---|---|
| `rild` NEEDS | `libql_ril.so` | `libparticle_ril.so` |
| library shipped in the deb | none | `/usr/lib/aarch64-linux-gnu/libparticle_ril.so` |
| result on device | `status=127`, both units dead | resolves |

## Verified

Observed on head2-tachyon (formfactor_dvt, NA headless) running
`1.2.12-dev+build.2cb7d65`, which carries the stock `0.5.5-1`. Confirmed the
same package is what the repo serves today, and that its deb has been unchanged
since 25 Aug 23:32 — i.e. before both 1.2.11 and 1.2.12, so every current 24.04
build has this defect.

0.6.0-1 contents were inspected directly from
`pool/latest/p/pa/particle-tachyon-ril_0.6.0-1_arm64.deb`
(SHA256 `a5f1c40c937fa5754fe161df795214de3c62b077be1d5b6aef5fbc1f4ff4c358`).

A matching 20.04 PR bumps the same package in `tachyon-release-builder`.

## Note

`0.6.0-1` still declares `Depends: libc6, libsqlite3-0, libsystemd0, socat` — it
resolves the failure by bundling the library rather than by declaring a dependency
on it, so the packaging is self-consistent but the dependency metadata is still
not describing the real linkage. Worth a follow-up on the package itself.
