### PR TITLE
24.04: add the misc partition, and stop partition indices from breaking boot

### DIFF
--- a/scripts/assemble/config/partition_ext.xml
+++ b/scripts/assemble/config/partition_ext.xml
@@ -15,6 +15,7 @@
     <physical_partition>
         <partition label="efi" 			    size_in_kb="524288" 	type="C12A7328-F81F-11D2-BA4B-00A0C93EC93B" bootable="false" readonly="true" 	system="true" dontautomount="true" filename="efi.bin"/>
 		<partition label="persist" 		    size_in_kb="30720" 		type="0FC63DAF-8483-4772-8E79-3D69D8477DE4" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>	
+		<partition label="misc" 		    size_in_kb="1024" 		type="82ACC91F-357C-4A68-9C8F-689E1B1A23A1" bootable="false" readonly="false" 	system="true" dontautomount="true" filename=""/>
 		<partition label="system" 		    size_in_kb="10485760" 	type="B921B045-1DF0-41C3-AF44-4C6F280D3FAE" bootable="false" readonly="false" 	system="true" dontautomount="true" filename="system.img"/> 
 	</physical_partition>                   
 										    

--- a/scripts/efi/grub-efi-src-dir/EFI/BOOT/grub.cfg
+++ b/scripts/efi/grub-efi-src-dir/EFI/BOOT/grub.cfg
@@ -5,6 +5,10 @@ set timeout_style=hidden
 search --no-floppy --file /boot/vmlinuz --set=root
 
 menuentry 'Ubuntu 24.04 (Tachyon)' {
-    linux /boot/vmlinuz root=/dev/sda3 rw console=ttyMSM0,115200n8 rootwait
+    # Resolve the rootfs by partition label, not by /dev/sdaN. The index shifts
+    # whenever a partition is added ahead of it on LUN 0 -- adding misc moved
+    # system from sda3 to sda4 -- and the label does not. Matches how the
+    # overlays' fstab already mounts persist, dtb_a and core_nhlos_a.
+    linux /boot/vmlinuz root=PARTLABEL=system rw console=ttyMSM0,115200n8 rootwait
     initrd /boot/initrd.img
 }

--- a/scripts/efi/make-efi-img.sh
+++ b/scripts/efi/make-efi-img.sh
@@ -5,6 +5,51 @@ set -euo pipefail
 # Resolve sources relative to this script, so it works regardless of the caller's cwd.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GRUB_SRC_DIR="${SCRIPT_DIR}/grub-efi-src-dir/EFI/BOOT"
+PARTITION_XML="${SCRIPT_DIR}/../assemble/config/partition_ext.xml"
+
+# 0) Check that grub's root= names a partition that actually exists.
+#
+# root=/dev/sdaN is the failure this guards against: partition indices shift
+# whenever anything is added ahead of them. Adding misc to LUN 0 moved system
+# from sda3 to sda4, and the stale root=/dev/sda3 handed the kernel a 1MiB
+# partition with no filesystem -- the board flashed cleanly, then stopped in
+# initramfs with "No init found". Nothing in the build noticed, because nothing
+# checked. A label does not move, so index-based roots are rejected outright and
+# a label-based one must match the partition table shipped beside it.
+check_grub_root() {
+  local cfg="${GRUB_SRC_DIR}/grub.cfg"
+  [ -r "$cfg" ] || { echo "ERROR: cannot read $cfg" >&2; exit 1; }
+
+  local root
+  root="$(grep -oE 'root=[^[:space:]]+' "$cfg" | head -1 || true)"
+  [ -n "$root" ] || { echo "ERROR: no root= in $cfg" >&2; exit 1; }
+
+  case "$root" in
+    root=/dev/*)
+      echo "ERROR: $cfg uses '$root'." >&2
+      echo "       Device-node roots break whenever the partition table changes." >&2
+      echo "       Use root=PARTLABEL=<label> instead." >&2
+      exit 1
+      ;;
+    root=PARTLABEL=*)
+      local label="${root#root=PARTLABEL=}"
+      [ -r "$PARTITION_XML" ] || {
+        echo "ERROR: cannot read $PARTITION_XML to verify '$root'" >&2; exit 1; }
+      if ! grep -q "label=\"${label}\"" "$PARTITION_XML"; then
+        echo "ERROR: $cfg boots root=PARTLABEL=${label}, but no partition with" >&2
+        echo "       label=\"${label}\" exists in $PARTITION_XML." >&2
+        exit 1
+      fi
+      echo "OK: grub root=PARTLABEL=${label} matches a partition in the table"
+      ;;
+    *)
+      echo "ERROR: $cfg uses '$root', which is neither a device node nor a" >&2
+      echo "       PARTLABEL. Refusing to ship a root= this script cannot verify." >&2
+      exit 1
+      ;;
+  esac
+}
+check_grub_root
 
 # 1) Create an empty 512MB image
 dd if=/dev/zero of=efi.img bs=1M count=512


### PR DESCRIPTION
## What

Three commits that together add a `misc` partition to the 24.04 image and stop the
addition from breaking boot.

| commit | change |
|---|---|
| `9a96e21` | `partition_ext.xml`: add a 1 MiB `misc` partition to LUN 0, after `persist` |
| `e09bc5a` | `grub.cfg`: resolve the rootfs by `PARTLABEL=system`, not `/dev/sda3` |
| `369b539` | `make-efi-img.sh`: fail the build if grub's `root=` cannot be verified |

## Why

`particle tachyon setup` writes its first-boot configuration blob (password, Wi-Fi,
registration code) to the `misc` partition, and 24.04 did not have one. On a device
already running 24.04, setup failed outright with
`Partition misc not found in device partition table`. On a 20.04 device it resolved the
*old* `misc` LBA and then wrote the blob to whatever ended up on those sectors after the
24.04 image was flashed.

`misc` is non-A/B, read-write, has no image payload, and matches
`tachyon-unpacking-tool/common/config/ufs/partition_ext.xml` exactly. It is inserted
*before* the growable last partition, so `LUNtoGrow="0"` +
`GROW_LAST_PARTITION_TO_FILL_DISK` still absorb the 64 GB / 128 GB SKU difference:
`system` stays last on LUN 0 and keeps `num_partition_sectors="0"`.

### The second and third commits are the interesting ones

Adding `misc` shifts every LUN 0 partition after `persist` by 256 sectors, so `system`
moved from **sda3 to sda4**. `grub.cfg` hardcoded `root=/dev/sda3`, so the first build of
this branch flashed fine and then dropped to an initramfs shell. Confirmed on hardware
from that shell — `misc -> sda3` (no TYPE), `system -> sda4 TYPE="ext4"`.

`e09bc5a` switches to `root=PARTLABEL=system`, which is how the overlays' fstab already
mounts `persist`, `dtb_a` and `core_nhlos_a`. Labels do not move when a partition is
inserted ahead of them; indices do.

`369b539` makes that class of bug a build failure rather than a bricked board. Before the
EFI image is assembled it reads `root=` out of `grub.cfg` and requires it to be
`PARTLABEL=<label>` with `<label>` actually present in `partition_ext.xml`. Anything else
— a `/dev/sdaN` path, a `UUID=`, a label with no matching partition, a missing `root=` —
exits 1.

Verified:

| `root=` | result |
|---|---|
| `PARTLABEL=system` | rc=0 |
| `/dev/sda3` | rc=1 |
| `PARTLABEL=nosuchlabel` | rc=1 |
| `UUID=1234` | rc=1 |

## Verification

**ptool artifact diff, LUNs 1–6 byte-identical to `main`.** On LUN 0, `misc` lands at
sector 138758 for 256 sectors and `system` shifts 138758 → 139014, keeping
`num_partition_sectors="0"` so it still grows to fill the disk.

Confirmed in the published artifact (`rawprogram0.xml` from
`tachyon-ubuntu-24.04-NA-headless-1.2.14-dev+build.64a0cda.zip`) — exactly one `misc`
across all seven rawprogram files, on LUN 0:

```
efi      start=6       sectors=131072
persist  start=131078  sectors=7680
misc     start=138758  sectors=256      <- 1024.0 KB
system   start=139014  sectors=0        <- last, grows to fill disk
```

**Hardware — head2, full `particle tachyon setup` on a device already running 24.04, no
UFS reprovisioning, build `1.2.14-dev+build.64a0cda`:**

(head2 has been on 24.04 since it was reflashed with `24.04-NA-headless-1.2.11` on
27 Aug, so both runs here are 24.04 → 24.04. The 20.04 → 24.04 direction is **not**
exercised by this PR's testing — it was covered separately by composer `dd73135`.)

```
PRETTY_NAME="Ubuntu 24.04.4 LTS"     kernel 6.8.0-1058-particle
/proc/cmdline  BOOT_IMAGE=/boot/vmlinuz root=PARTLABEL=system rw console=ttyMSM0,115200n8 rootwait
rootfs         /dev/sda4 ext4
misc    -> ../../sda3     1048576 bytes  (exactly 1 MiB)
persist -> ../../sda2
system  -> ../../sda4
```

Boots to a login. `misc` is entirely zero after first boot (sha256 of the whole 1 MiB ==
sha256 of 1 MiB of zeros), i.e. the config blob was written, consumed by the particle-linux
bootstrap and wiped. The configured password authenticates against `/etc/shadow`
(sha512crypt match for `particle`). Wi-Fi associated to the configured SSID and got a DHCP
lease.

**Modem NV preserved in place** — all six partitions byte-identical to the pre-flash
capture, with `nvdata1/2` still at the 20.04 1.5 MiB sizes:

| partition | bytes | sha256 (16) | pre-flash |
|---|---|---|---|
| modemst1 | 4194304 | `bf3b6f0917eb5cf8` | same |
| modemst2 | 4194304 | `a00c952ec429e5b5` | same |
| fsc | 131072 | `fa43239bcee7b97c` | same |
| fsg | 4194304 | `abccf416cf41458e` | same |
| nvdata1 | 1572864 | `106f0647ae10a651` | same |
| nvdata2 | 1572864 | `106f0647ae10a651` | same |

**Second flash, 24.04 → 24.04 on the same board**: setup runs again, boots again, `misc`
again 1 MiB and again zeroed after first boot, modem identity intact
(`particle-tachyon-ril-ctl info` reports both IMEIs, ICCID, EID and firmware version).
`fsg`, `fsc` and `nvdata1/2` are byte-identical across both flashes. `modemst1/2` differ
between runs because they are the modem's live working EFS partitions — verified by
watching `modemst2` change hash within 90 s of idle runtime with no flashing at all.

The device also reboots cleanly under its own `reboot`, coming back to
`systemctl is-system-running` = `running` with **no failed units**, and all four fstab
mounts resolve: `/` on `sda4`, `/persist` on `sda2`, `/vendor` on `sdg15` (LUN 6, by
`PARTLABEL=core_nhlos_a`) and the `dtb_a` automount.

**The build-time check runs in CI** — all four build variants log
`OK: grub root=PARTLABEL=system matches a partition in the table`.

### On-image suites

| suite | result | baseline |
|---|---|---|
| `particle-linux-test` | 21 passed / 0 failed / 2 skipped | 20 / 0 / 3 |
| `particle-tachyon-gnss-test` | 41 passed / 2 failed / 9 skipped | 43 / 0 / 9 |
| `particle-tachyon-rild-test` | 74 passed / 3 failed | 78 / 0 / 0 |

Run the suites with a valid `TMPDIR`. Under `adb shell`, `TMPDIR` defaults to the Android
path `/data/local/tmp`, which does not exist on this image; the suites' output redirects
then fail and it surfaces as a bogus `'particlectl systemdoc' exited 2` with everything
downstream skipped. With `TMPDIR=/tmp`, `particle-linux-test` goes from 5/1/17 to 21/0/2.

The residual failures are **not attributable to this PR** — this branch changes three
files, none of which enter the rootfs: a GPT description, a grub config on the EFI
partition, and a build script. The rild failures are D-Bus interface-signature mismatches
(`Connect`/`Disconnect` signatures, `GetStatus` missing `state`/`signal-quality`/
`access-technologies`/`m3gpp-registration-state`), i.e. a rild-vs-test version skew. The
GNSS failures are both the same reproducible NMEA-callback stall. Both are worth chasing
separately; neither was re-run against a `main`-built image as a control.

## Landing note

`particle-cli` #933 is the consumer of this partition. Land this first and publish an
image containing `misc`, otherwise the CLI's post-flash `misc` resolution has nothing to
resolve.
