### PR TITLE
Retire ENV_UBUNTU_24_04_VERSION; pin the overlay repos

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -43,9 +43,9 @@
       "base_url": "https://linux-dist.particle.io/kernel/release"
     },
 
-    // Overlay stack applied to the rootfs (packages, configs, Particle services). On main: the
-    // new-BP overlays (add-qcm6490-bp-fw, fstab fix, link-ath11k/qca-bt/gpu/audio/modem, the 24.04
-    // stacks) gated behind `when: { env: ENV_UBUNTU_24_04_VERSION, min: "1.2" }` (PR #26 merged).
+    // Overlay stack applied to the rootfs (packages, configs, Particle services). The former
+    // 1.1 layout and its `when: { env: ENV_UBUNTU_24_04_VERSION, min: "1.2" }` gates were
+    // retired; the firmware/audio/modem overlays now apply unconditionally.
     "particle-iot/tachyon-overlay": {
       "type": "git_release",
       "param": "main"
@@ -93,12 +93,6 @@
 
     //The syscon package
     "PKG_particle_tachyon_syscon": "1.0.52-1",
-
-    //Ubuntu 24.04 distribution version. ENV_ (not PKG_) on purpose: check-pinned-packages treats
-    //every PKG_* as an apt package to install, but this is a plain config value. The overlay tool
-    //forwards ENV_* into the chroot, and the new-BP stack gates its firmware/audio/modem overlays
-    //on this via `when: { env: ENV_UBUNTU_24_04_VERSION, min: "1.2" }`.
-    "ENV_UBUNTU_24_04_VERSION": "1.2",
 
     //version used in the debian file to pin the version down
     "PIN_PRIORITY": "900"

--- a/versions.json
+++ b/versions.json
@@ -46,16 +46,25 @@
     // Overlay stack applied to the rootfs (packages, configs, Particle services). The former
     // 1.1 layout and its `when: { env: ENV_UBUNTU_24_04_VERSION, min: "1.2" }` gates were
     // retired; the firmware/audio/modem overlays now apply unconditionally.
+    // Pinned to a full 40-char commit sha, not `main`: the composer fetches this with
+    // `git fetch --depth 1 origin <ref>`, so a moving ref makes a build non-reproducible
+    // and lets overlay behaviour change under a composer release. Abbreviated shas do
+    // NOT work here -- the server rejects them ("couldn't find remote ref"). Bump this
+    // deliberately when you want new overlays.
+    // 4bbd8a89 = "Retire the 1.1 layout and the ENV_UBUNTU_24_04_VERSION gate" (#38).
     "particle-iot/tachyon-overlay": {
       "type": "git_release",
-      "param": "main"
+      "param": "4bbd8a8947f30862f66c4d4faf4eac9a2c67da31"
     },
 
     // The overlay TOOL (engine that applies the stack). Provides the `when` env-gate and ENV_*
     // chroot forwarding the new-BP stack relies on (PR #3 merged to main).
+    // Pinned for the same reason as tachyon-overlay above: full 40-char sha, bumped
+    // deliberately. This tool applies the overlay stack, so a silent change here rewrites
+    // how every overlay is applied.
     "particle-iot/tachyon-overlay-tool": {
       "type": "git_release",
-      "param": "main"
+      "param": "0b5f8fb597a8ba17e6e7035a0ca13d16ef29599c"
     },
 
     // The Kigen LPA (eSIM local profile assistant) shipped as a prebuilt binary.


### PR DESCRIPTION
## What

Removes `ENV_UBUNTU_24_04_VERSION` from `versions.json`, plus the two comments
describing the gate it drove.

## Why

The OS release version and the BP layout version were the **same number**, so the
variable only duplicated what the release version already said.

With the 1.1 layout retired in particle-iot/tachyon-overlays#38 there is nothing left
for it to select between:

- `install-fstab.sh` and `setup-rfs-paths.sh` each collapse to a single path
- the six `when: { env: ENV_UBUNTU_24_04_VERSION, min: "1.2" }` gates in
  `stacks/ubuntu-common-24.04.json` apply unconditionally

It has held `"1.2"` and nothing else since `651640a` introduced it on 2026-06-23.

## No output change

Every overlay it gated already ran, because this repo has always pinned `1.2`. The
installed `/etc/fstab` is byte-identical — the overlays PR renames `files/fstab.bp` to
`files/fstab` with the same content (sha256 `bab5052c…`).

## Ordering — satisfied

particle-iot/tachyon-overlays#38 **merged 2026-08-30 20:19Z** (`4bbd8a8`), so `main` no
longer reads `ENV_UBUNTU_24_04_VERSION` at all: `setup-rfs-paths.sh` has no `VERSION=`
line left, and `files/fstab.bp` is gone (renamed to `files/fstab`). The dependency this
PR carried is met and it is safe to merge.

### The floating `main` ref — now pinned (`cd1c5b0`)

Taking the review comment: both overlay repos are pinned to full commit shas.

```
particle-iot/tachyon-overlay        4bbd8a89…  "Retire the 1.1 layout …" (#38)
particle-iot/tachyon-overlay-tool   0b5f8fb5…  "Tear the chroot down …" (#6)
```

They were the only two of six sources not pinned — `bp-fw` `2.0.5`,
`tachyon-ubuntu-24.04` `26-0519f5b`, the kernel and `kigen-sdk` `0.1.8` already were —
so this brings them in line with the repo's own convention.

Both shas are the current `main` of each repo, so this pins to exactly what builds
already use; no behaviour change.

**Not pinned to the existing tags.** `tachyon-overlays` `0.1.3` is **40 commits behind**
`main` and predates the retirement, so pinning there would have reverted it.

**Use full 40-character shas.** The Makefile fetches with
`git fetch --depth 1 origin <ref>` then `checkout FETCH_HEAD`; the server rejects
abbreviated shas with `couldn't find remote ref`. Verified against both repos —
`0b5f8fb5` fails, the full sha succeeds.

Side effect worth knowing: `PKG_SRC_OVERLAYS` feeds `distro_versions.json`, so a built
image now records the exact overlays sha in `src.overlays` rather than the uninformative
`"main"`.

## 20.04 is unaffected

Checked explicitly:

- **composer has no 20.04 build path** — only `compose_24_04.sh` exists, and its header
  says it "replaces the legacy 20.04 + U-Boot path".
- `ENV_UBUNTU_24_04_VERSION` appears nowhere outside `versions.json`.
- Of the 7 files the overlays retirement touched, **none** is reachable from any 20.04
  stack. The 20.04 stacks reference 47 overlays; the intersection with the three overlays
  changed (`add-fstab-mounts`, `modem-tftp-server`, `link-modem-firmware`) is **empty**,
  and `stacks/ubuntu-common-24.04.json` is 24.04-only by name.
- Neither `tachyon-unpacking-tool` nor `tachyon-release-builder` — the 20.04 build path —
  references `tachyon-overlays` at all (0 hits in each).

## Note

`env` now holds only `PKG_*` entries plus `PIN_PRIORITY`, so nothing uses the `ENV_*`
forwarding path any more. The mechanism stays in `tachyon-overlay-tool` for future use —
worth knowing it currently has no callers.


