### PR TITLE
versions: particle-tachyon-ril 0.6.0-1 -> 0.6.1-1 (fixes the empty `status` output)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -97,8 +97,14 @@
     //This is the particle debian package
     "PKG_particle_linux": "0.25.1-1",
 
-    //Radio code (RIL)
-    "PKG_particle_tachyon_ril": "0.6.0-1",
+    //Radio code (RIL). 0.6.1 fixes the `status` regression that arrived with 0.6.0's
+    //ModemManager backend: GetStatus returned an empty a{sv} when a registered modem had an
+    //incomplete cell identity, so particle-tachyon-ril-ctl printed nothing and still exited 0.
+    //It also puts +CEREG=2 and +CMEE=2 back on the AT channel -- the vendor stack used to set
+    //them, and rild's "SIM failure" match and the SMS error-cause parse both already depended
+    //on them -- and re-applies them when ModemManager re-exports the modem after a reset.
+    //Published to the `latest` feed, not `stable`, exactly as 0.6.0-1 is.
+    "PKG_particle_tachyon_ril": "0.6.1-1",
 
     //The syscon package
     "PKG_particle_tachyon_syscon": "1.0.52-1",


### PR DESCRIPTION
Bumps the RIL pin one patch release. One line of actual change in `versions.json`, plus a comment recording why.

## What 0.6.1 fixes

**The `status` regression 0.6.0 shipped.** 0.6.0 replaced the vendor `libql_ril.so` with `libparticle_ril.so` and a ModemManager backend (#75). That backend regressed `particle-tachyon-ril-ctl status`:

```c
r = sd_bus_call_method(bus, service, object_path, interface, "GetStatus", &error, &reply, "");
if (r < 0) { fprintf(stderr, "Failed to call GetStatus: %s\n", error.message); }
else { sd_bus_message_enter_container(reply, 'a', "{sv}"); render_dbus_dictionary(reply); }
return r < 0 ? 1 : 0;
```

`GetStatus` returned an empty `a{sv}` when a registered modem had an incomplete cell identity, so `ctl` entered the container, found nothing to render, printed nothing, and still exited `0`. Silence and success looked identical to anything scripting it.

It was only `status`. `status --get`, `state`, `vitals`, `info` and `sim status` all produced output on 0.6.0, which is why it went unnoticed.

0.6.1 checks the invariant directly — a registered modem must have a complete cell identity — and reports `cgi_valid` and the fields behind it when the assertion fails.

**AT channel configuration.** 0.6.1 also sets `+CEREG=2` (so the modem reports location alongside its registration) and `+CMEE=2` on the AT channel. The vendor stack used to set both; `rild`'s "SIM failure" match and the SMS backend's error-cause parse each already depended on them without either one setting it. It re-applies them when ModemManager re-exports the modem, since a reset takes the settings with it while the port stays open and AT keeps answering.

## Feed availability

Confirmed against `packages.particle.io` for `binary-arm64`:

| feed | newest `particle-tachyon-ril` |
|---|---|
| `stable` | `0.4.5-1` |
| `latest` | `0.6.0-1`, **`0.6.1-1`** |

So 0.6.1-1 sits in `latest`, exactly where 0.6.0-1 already is. `stacks/ubuntu-common-24.04.json` adds `add-particle-repo` (which configures both `stable` and `latest`) before installing `particle-tachyon-deb`, so the pin resolves the same way today's does. No change to which feeds end up configured on the shipped image.

## Checks

- `versions.json` still parses through the Makefile's own comment-stripping regex (`^\s*//.*$`, MULTILINE); `_ENV_JSON` yields `PKG_particle_tachyon_ril=0.6.1-1`.
- `0.6.0` appears nowhere else in the repo — this was the only reference.

## Not verified here

The fix has not been exercised on hardware from this branch. `status` returning output again is worth one check on head2 after the next build, alongside confirming `+CEREG=2` survives a modem reset — that re-apply path is the part with no test behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA
