### PR TITLE
versions: particle-tachyon-ril 0.6.1-1 -> 0.6.2-1, overlays -> dc2f331

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -51,10 +51,10 @@
     // and lets overlay behaviour change under a composer release. Abbreviated shas do
     // NOT work here -- the server rejects them ("couldn't find remote ref"). Bump this
     // deliberately when you want new overlays.
-    // 4bbd8a89 = "Retire the 1.1 layout and the ENV_UBUNTU_24_04_VERSION gate" (#38).
+    // dc2f331b = "set-initial-time: compare against the setup time, not a hardcoded 2024" (#39).
     "particle-iot/tachyon-overlay": {
       "type": "git_release",
-      "param": "4bbd8a8947f30862f66c4d4faf4eac9a2c67da31"
+      "param": "dc2f331bdefc61835c8f63d8536ee48befb71c31"
     },
 
     // The overlay TOOL (engine that applies the stack). Provides the `when` env-gate and ENV_*
@@ -97,14 +97,22 @@
     //This is the particle debian package
     "PKG_particle_linux": "0.25.1-1",
 
-    //Radio code (RIL). 0.6.1 fixes the `status` regression that arrived with 0.6.0's
-    //ModemManager backend: GetStatus returned an empty a{sv} when a registered modem had an
-    //incomplete cell identity, so particle-tachyon-ril-ctl printed nothing and still exited 0.
-    //It also puts +CEREG=2 and +CMEE=2 back on the AT channel -- the vendor stack used to set
-    //them, and rild's "SIM failure" match and the SMS error-cause parse both already depended
-    //on them -- and re-applies them when ModemManager re-exports the modem after a reset.
-    //Published to the `latest` feed, not `stable`, exactly as 0.6.0-1 is.
-    "PKG_particle_tachyon_ril": "0.6.1-1",
+    //Radio code (RIL). 0.6.2 fixes three things a 1.2.17 setup run on head2 surfaced.
+    //Slot reporting: QMI marks both physical slots active on this modem, ModemManager
+    //resolves that by naming the last one, so every boot compared slot 2 against a
+    //configured slot 1, asked for a switch the modem refused with a QMI "Internal" error,
+    //and power-cycled the modem on a device already on the right SIM. 0.6.2 reports the
+    //slot the modem is actually using, and waits and retries where a switch is genuinely
+    //needed. Modem-info reads: nothing refreshes them on a timer, so the startup pass --
+    //the one with no earlier value to fall back on -- ran before ModemManager had exported
+    //a modem and left baseband-version and eid reading `unavailable` for the whole boot.
+    //0.6.2 keeps the last known value and re-runs the refresh with widening backoff, so
+    //`unavailable` means "asked, has none" rather than "could not ask". It also stops
+    //reporting a refused ModemManager call as "ModemManager is not answering" -- an error
+    //reply is the service answering -- and defaults TMPDIR in the on-image suites, which
+    //`sudo` strips and `set -u` then aborts on.
+    //Published to the `latest` feed, not `stable`, exactly as 0.6.0-1 and 0.6.1-1 are.
+    "PKG_particle_tachyon_ril": "0.6.2-1",
 
     //The syscon package
     "PKG_particle_tachyon_syscon": "1.0.52-1",


### PR DESCRIPTION
Two pins, both carrying fixes for defects that a real `particle tachyon setup` run against 1.2.17 on head2 surfaced.

## particle-tachyon-ril 0.6.2-1

**Every boot logged a SIM slot switch that was neither wanted nor possible:**

```
SetPrimarySimSlot: QMI protocol error (3): 'Internal'
```

QMI marks both physical slots active on this modem. ModemManager resolves that ambiguity by naming the last one, so `PrimarySimSlot` read 2, the configured slot was 1, and rild asked for a switch on every startup — which the modem refused, after power-cycling itself, on a device that was already on the right SIM. 0.6.2 reports the slot the modem is actually using, and waits and retries for the boards where a switch is genuinely needed.

**`particle-tachyon-ril-ctl info` intermittently reported fields the modem plainly had.** Observed on head2 across two boots, with `mmcli` holding the value the whole time:

```
baseband-version: unavailable      # mmcli: SG560DNAPAR60A03  1  [Oct 08 2023 09:00:00]
```

Nothing refreshes modem-info on a timer, so the startup pass — the one with no earlier value to fall back on — ran before ModemManager had exported a modem, and the field stayed `unavailable` for the life of that boot. 0.6.2 keeps the last known value and re-runs the refresh with widening backoff, so `unavailable` recovers its meaning: *the modem was asked and has none*, not *this pass could not ask*.

Also in 0.6.2: a refused ModemManager call is no longer reported as "ModemManager is not answering" (an error reply is the service answering, and reading it as an outage sends an operator hunting a dead service that is fine), and the on-image suites default `TMPDIR`, which `sudo` strips and `set -u` then aborts on.

Published to `latest`, not `stable`, exactly as 0.6.0-1 and 0.6.1-1 are — confirmed against the arm64 `Packages` index for both suites.

## tachyon-overlay `dc2f331b`

Picks up **"set-initial-time: compare against the setup time, not a hardcoded 2024"** (particle-iot/tachyon-overlays#39).

`set-initial-time` had been a no-op since 1 January 2025:

```python
def is_time_bad() -> bool:
    return datetime.datetime.utcnow().year == 2024
```

The board has no battery-backed clock, so it starts at the epoch and systemd drags it forward to the image build date. Neither is 2024 any more, so the guard returned `False` and the service skipped — and the whole first-boot sequence (password, Wi-Fi, registration, CLI config) logged under the build date rather than the real one. It now compares against the `initialTime` that setup stamps into the config blob.

## Verified

- Parsed with the Makefile's own comment-stripping reader: ril resolves to `0.6.2-1`, the overlay pin to the full 40-char `dc2f331b...`.
- `make -n build_24.04 INPUT_REGION=NA INPUT_VARIANT=headless` puts `PKG_particle_tachyon_ril=0.6.2-1` into the overlay env.
- The pinned sha fetches the way the composer fetches it — `git fetch --depth 1 origin <sha>` — which abbreviated shas do not.
- `particle-tachyon-ril 0.6.2-1` present in the `latest` arm64 index; absent from `stable`, as expected.

No other pins moved: `particle-linux` stays 0.25.1-1, syscon 1.0.52-1, overlay-tool `0b5f8fb5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA
