### PR TITLE
26.04 branch: specialise the composer for Ubuntu 26.04 [skip ci]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,21 @@
-name: Build Tachyon 24.04
+name: Build Tachyon 26.04
+
+# 26.04-only composer branch. `main` builds 24.04; this branch builds 26.04 and
+# NEVER writes the served OTA channels (latest/stable) -- 26.04 is gated to an
+# un-served preview manifest until deliberately promoted. 26.04 versions live on
+# an independent '26.04/'-namespaced tag stream (see the Determine version step),
+# so they never collide with 24.04's bare 1.2.x tags.
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
+    branches:
+      - '26.04'
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-*'
+      # 26.04 releases only. '*' does not cross '/', so bare 24.04 tags never match.
+      - '26.04/[0-9]+.[0-9]+.[0-9]+'
+      - '26.04/[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
 
 jobs:
@@ -49,7 +58,7 @@ jobs:
 
       - name: Install tachyon-dist-tools
         env:
-          DIST_TOOLS_VERSION: ${{ vars.DIST_TOOLS_VERSION || '1.0.3' }}
+          DIST_TOOLS_VERSION: ${{ vars.DIST_TOOLS_VERSION || '1.0.4' }}
         run: |
           set -euo pipefail
           pip install "https://github.com/particle-iot/tachyon-dist-tools/releases/download/${DIST_TOOLS_VERSION}/tachyon_dist_tools-${DIST_TOOLS_VERSION}-py3-none-any.whl"
@@ -61,19 +70,22 @@ jobs:
           GH_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ "$GH_REF" == refs/tags/* ]]; then
-            VERSION=$(tachyon-resolve-version --build-type release)
+          # 26.04 uses a '26.04/'-namespaced tag stream (independent of 24.04's bare
+          # 1.2.x tags on main), seeded at 1.3.0. Only a '26.04/x.y.z' tag is a
+          # release; PRs, branch pushes and dispatch are prereleases (1.3.0-dev+...).
+          if [[ "$GH_REF" == refs/tags/26.04/* ]]; then
+            VERSION=$(tachyon-resolve-version --build-type release --tag-prefix "26.04/")
             IS_RELEASE="true"
           else
             SHORT_SHA="$(git rev-parse --short=7 HEAD)"
-            VERSION=$(tachyon-resolve-version --build-type prerelease --build-id "build.${SHORT_SHA}")
+            VERSION=$(tachyon-resolve-version --build-type prerelease --build-id "build.${SHORT_SHA}" --tag-prefix "26.04/" --seed-version 1.3.0)
             IS_RELEASE="false"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "is_release=${IS_RELEASE}" >> "$GITHUB_OUTPUT"
-          echo "Resolved version: ${VERSION} (is_release=${IS_RELEASE})"
+          echo "Resolved 26.04 version: ${VERSION} (is_release=${IS_RELEASE})"
 
-      - name: Build (Ubuntu 24.04)
+      - name: Build (Ubuntu 26.04)
         id: build_step
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -90,14 +102,14 @@ jobs:
           KIGEN_SDK_TOKEN: ${{ secrets.KIGEN_SDK_TOKEN }}
         run: |
           set -euo pipefail
-          OUTNAME="tachyon-ubuntu-24.04-${REGION}-${VARIANT}-${VERSION}.zip"
+          OUTNAME="tachyon-ubuntu-26.04-${REGION}-${VARIANT}-${VERSION}.zip"
 
-          make build_24.04 \
-            VERSIONS_FILE=./versions.json \
+          make build_26.04 \
+            VERSIONS_FILE=./versions-26.04.json \
             INPUT_REGION="${REGION}" \
             INPUT_VARIANT="${VARIANT}" \
             OUTPUT_VERSION="${VERSION}" \
-            OUTPUT_24_04_SYSTEM_IMAGE="${OUTNAME}"
+            OUTPUT_SYSTEM_IMAGE="${OUTNAME}"
 
           URL_ENCODED="$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$OUTNAME")"
           echo "output_name=${OUTNAME}" >> "$GITHUB_OUTPUT"
@@ -143,7 +155,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            **PR build uploaded** for **${{ matrix.region }} ${{ matrix.variant }}**
+            **PR build uploaded** for **26.04 ${{ matrix.region }} ${{ matrix.variant }}**
             **Version:** `${{ steps.ver.outputs.version }}`
             **Download:** [URL](https://linux-dist.particle.io/prerelease/${{ steps.build_step.outputs.url_encoded_name }})
 
@@ -282,7 +294,7 @@ jobs:
 
       - name: Install tachyon-dist-tools
         env:
-          DIST_TOOLS_VERSION: ${{ vars.DIST_TOOLS_VERSION || '1.0.3' }}
+          DIST_TOOLS_VERSION: ${{ vars.DIST_TOOLS_VERSION || '1.0.4' }}
         run: |
           set -euo pipefail
           pip install "https://github.com/particle-iot/tachyon-dist-tools/releases/download/${DIST_TOOLS_VERSION}/tachyon_dist_tools-${DIST_TOOLS_VERSION}-py3-none-any.whl"
@@ -326,11 +338,11 @@ jobs:
             jq -n --arg ver "$VERSION" --arg now "$NOW" --arg url "$URL" \
               --arg sha "$SHA256" --arg variant "$VARIANT" --arg region "$REGION" \
               '{
-                release_name: ("tachyon-ubuntu-24.04-" + $region + "-" + $variant + "-" + $ver),
+                release_name: ("tachyon-ubuntu-26.04-" + $region + "-" + $variant + "-" + $ver),
                 version: $ver, region: $region, variant: $variant,
                 platform: "qcm6490", board: "formfactor_dvt",
                 os: "linux", distribution: "ubuntu",
-                distribution_version: "24.04", distribution_variant: "ubuntu",
+                distribution_version: "26.04", distribution_variant: "ubuntu",
                 build_date: $now,
                 artifacts: [{ artifact_url: $url, sha256_checksum: $sha, type: "release_image" }]
               }' > "build_meta/${BASENAME}.json"
@@ -355,8 +367,11 @@ jobs:
           set -euo pipefail
           aws s3 cp release_metadata.json \
             "s3://${LINUX_DIST_S3_BUCKET}/${METADATA_KEY}" \
-            --only-show-errors
+            --content-type application/json --only-show-errors
 
+          # 26.04 per-version manifests are ALWAYS tagged prerelease lifecycle: they
+          # are immutable per-version records, never the served channel. (26.04 is
+          # deliberately kept off latest/stable; see publish_release.)
           if [[ "$IS_RELEASE" != "true" ]]; then
             aws s3api put-object-tagging \
               --bucket "$LINUX_DIST_S3_BUCKET" \
@@ -386,7 +401,11 @@ jobs:
           path: release_metadata.json
           retention-days: 30
 
-  # ── GitHub Release + latest.json (tag builds only) ───────────────────
+  # ── GitHub Release + 26.04 preview manifest (tag builds only) ─────────
+  # 26.04 NEVER touches the served channels (latest/stable). On a 26.04/x.y.z tag
+  # it publishes a GitHub Release and, when explicitly enabled, an un-served
+  # preview manifest. Promotion to the fleet OTA channels is a separate, deliberate
+  # step that does not live on this branch.
   publish_release:
     needs: [build, publish_metadata]
     runs-on: ubuntu-latest
@@ -398,12 +417,12 @@ jobs:
     if: >-
       needs.build.result == 'success'
       && needs.publish_metadata.result == 'success'
-      && needs.build.outputs.is_release == 'true'
+      && startsWith(github.ref, 'refs/tags/')
     env:
       LINUX_DIST_S3_BUCKET: ${{ secrets.LINUX_DIST_S3_BUCKET }}
       AWS_REGION:           ${{ secrets.AWS_REGION }}
-      RELEASE_METADATA_KEY: ${{ vars.RELEASE_METADATA_KEY || 'meta/tachyon-latest.json' }}
-      PUSH_JSON:            ${{ vars.PUSH_JSON || 'false' }}
+      # Off by default: publishing even the un-served 26.04 preview is opt-in.
+      PUSH_26_04_JSON:      ${{ vars.PUSH_26_04_JSON || 'false' }}
     steps:
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v5
@@ -424,7 +443,7 @@ jobs:
 
       - name: Install tachyon-dist-tools
         env:
-          DIST_TOOLS_VERSION: ${{ vars.DIST_TOOLS_VERSION || '1.0.3' }}
+          DIST_TOOLS_VERSION: ${{ vars.DIST_TOOLS_VERSION || '1.0.4' }}
         run: |
           set -euo pipefail
           pip install "https://github.com/particle-iot/tachyon-dist-tools/releases/download/${DIST_TOOLS_VERSION}/tachyon_dist_tools-${DIST_TOOLS_VERSION}-py3-none-any.whl"
@@ -435,11 +454,24 @@ jobs:
           name: release-metadata-json
           path: .
 
+      - name: Determine released version
+        id: rel
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Tag is '26.04/x.y.z'. VERSION is clean semver for display; TAG_REF is the
+          # actual git ref for the changelog range and the GitHub Release tag.
+          VERSION="${TAG_REF#26.04/}"
+          echo "version=${VERSION}"   >> "$GITHUB_OUTPUT"
+          echo "tag_ref=${TAG_REF}"   >> "$GITHUB_OUTPUT"
+          echo "Releasing 26.04 ${VERSION} (tag ${TAG_REF})"
+
       - name: Resolve previous version
         id: versel
         run: |
           set -euo pipefail
-          PREV=$(tachyon-resolve-version --build-type release --get-previous-version)
+          PREV=$(tachyon-resolve-version --build-type release --get-previous-version --tag-prefix "26.04/")
           echo "prev=$PREV" >> "$GITHUB_OUTPUT"
 
       - name: Build changelog from PRs
@@ -447,7 +479,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           fromTag: ${{ steps.versel.outputs.prev }}
-          toTag:   ${{ needs.build.outputs.version }}
+          toTag:   ${{ steps.rel.outputs.tag_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -455,7 +487,7 @@ jobs:
         id: contribs
         env:
           FROM_TAG: ${{ steps.versel.outputs.prev }}
-          TO_TAG: ${{ needs.build.outputs.version }}
+          TO_TAG: ${{ steps.rel.outputs.tag_ref }}
         run: |
           set -euo pipefail
           FROM="$FROM_TAG"
@@ -485,20 +517,23 @@ jobs:
       - name: Build release body
         id: body
         env:
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ steps.rel.outputs.version }}
+          TAG_REF: ${{ steps.rel.outputs.tag_ref }}
           PREV: ${{ steps.versel.outputs.prev }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
           GH_REPO: ${{ github.repository }}
           CONTRIBUTORS: ${{ steps.contribs.outputs.contributors }}
         run: |
           set -euo pipefail
+          # release_metadata.json here contains only 26.04 builds (this branch builds
+          # one series), so no filtering is needed before the note builder.
           tachyon-gh-note-builder release_metadata.json -o images_section.md
 
           CLEAN_CHANGES="$(printf '%s\n' "$CHANGELOG" \
             | sed -E '/^##[[:space:]].*$/d')"
 
           {
-            echo "${VERSION}"
+            echo "Ubuntu 26.04 — ${VERSION}"
             echo
             cat images_section.md
             echo
@@ -510,7 +545,7 @@ jobs:
               printf '%s\n' "$CLEAN_CHANGES"
             fi
             echo
-            echo "**Full Changelog**: https://github.com/${GH_REPO}/compare/${PREV:-0.0.0}...${VERSION}"
+            echo "**Full Changelog**: https://github.com/${GH_REPO}/compare/${PREV:-0.0.0}...${TAG_REF}"
             echo
             echo "Contributors"
             echo "$CONTRIBUTORS"
@@ -519,101 +554,30 @@ jobs:
       - name: Create/Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.build.outputs.version }}
-          name: ${{ needs.build.outputs.version }}
+          tag_name: ${{ steps.rel.outputs.tag_ref }}
+          name: Ubuntu 26.04 ${{ steps.rel.outputs.version }}
           body_path: RELEASE_BODY.md
           draft: false
-          prerelease: ${{ contains(needs.build.outputs.version, '-') }}
+          prerelease: ${{ contains(steps.rel.outputs.version, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update S3 release metadata (latest.json)
-        if: env.PUSH_JSON == 'true'
-        run: |
-          set -euo pipefail
-          tachyon-update-published-metadata \
-            "$LINUX_DIST_S3_BUCKET" \
-            "${RELEASE_METADATA_KEY}" \
-            release_metadata.json \
-            --origin "24.04"
-
-      # ----------------------------------------------------------------------
-      # HACK (temporary): the 24.04 line (1.2.x new-BP/A/B) is not production
-      # stable, so the CLI must not serve it as the default. Pin the published
-      # 24.04 entries to the last good release (1.1.43, desktop only — 1.1.43
-      # never shipped a 24.04 headless image) in BOTH the `latest` channel
-      # (force-replacing whatever this release just published) and a `stable`
-      # channel (seeded here). Touches ONLY the 24.04 builds; every other
-      # distribution (20.04, android, …) in the manifests is left untouched.
-      # sha256_checksum is intentionally empty — 1.1.43 published no checksum
-      # and the CLI skips verification when it is absent. REMOVE this step once
-      # a real 24.04 stable ships and update the generation to publish it.
-      # ----------------------------------------------------------------------
-      - name: 'HACK: pin 24.04 to 1.1.43 (desktop) in latest + stable'
-        if: env.PUSH_JSON == 'true'
+      - name: Publish 26.04 preview metadata (un-served channel)
+        if: env.PUSH_26_04_JSON == 'true'
         env:
-          PIN_VERSION: '1.1.43'
-          LATEST_KEY: ${{ vars.RELEASE_METADATA_KEY || 'meta/tachyon-latest.json' }}
-          STABLE_KEY: 'meta/tachyon-stable.json'
+          PREVIEW_KEY: 'meta/tachyon-26.04-preview.json'
           CF_DIST_ID: ${{ secrets.LINUX_DIST_CLOUDFRONT_DISTRIBUTION_ID }}
-          # Released 24.04 images live at /releases/<ver>/<region>/ (verified HTTP 200);
-          # this matches the existing 24.04 entries, NOT the singular /release/ that 20.04 uses.
-          RELEASES_BASE_URL: 'https://linux-dist.particle.io/releases'
         run: |
           set -euo pipefail
-
-          # The two pinned 1.1.43 24.04 desktop builds (NA + RoW). No headless
-          # (1.1.43 has none). sha256_checksum left "" so the CLI does not verify.
-          PINNED="$(jq -n --arg ver "$PIN_VERSION" --arg base "$RELEASES_BASE_URL" '
-            ["NA","RoW"] | map({
-              release_name: ("tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver),
-              version: $ver, region: ., variant: "desktop",
-              platform: "qcm6490", board: "formfactor_dvt",
-              os: "linux", distribution: "ubuntu",
-              distribution_version: "24.04", distribution_variant: "ubuntu",
-              build_date: "2026-02-10T22:40:34.082161",
-              artifacts: [{
-                artifact_url: ($base + "/" + $ver + "/" + . + "/tachyon-ubuntu-24.04-" + . + "-desktop-" + $ver + ".zip"),
-                sha256_checksum: "", type: "release_image"
-              }]
-            })')"
-
-          # Replace ONLY the 24.04 builds in a manifest, preserving all others.
-          # $1 = s3 key, $2 = "seed" to allow creating the object when it genuinely
-          # does not exist (404). We check existence with head-object FIRST: if the
-          # object exists we MUST read it successfully (set -e aborts on a transient
-          # read failure) so we never silently fall back to an empty skeleton and
-          # clobber the other distributions; the skeleton is used ONLY for a true 404.
-          pin_24_04 () {
-            local key="$1" mode="$2" cur new
-            if aws s3api head-object --bucket "$LINUX_DIST_S3_BUCKET" --key "$key" >/dev/null 2>&1; then
-              cur="$(aws s3 cp "s3://${LINUX_DIST_S3_BUCKET}/${key}" -)"
-            elif [ "$mode" = "seed" ]; then
-              echo "note: ${key} does not exist yet; seeding a new manifest"
-              cur="$SKEL"
-            else
-              echo "ERROR: ${key} not found (or unreadable); refusing to overwrite it from an empty skeleton" >&2
-              exit 1
-            fi
-            # Build + sanity-check the result in memory BEFORE uploading, so a jq
-            # failure can never write a truncated/empty object to S3.
-            new="$(printf '%s' "$cur" | jq --argjson pinned "$PINNED" \
-              '.builds = ([.builds[]? | select(.distribution_version != "24.04")] + $pinned)')"
-            printf '%s' "$new" | jq -e '.builds | length > 0' >/dev/null
-            printf '%s' "$new" | aws s3 cp - "s3://${LINUX_DIST_S3_BUCKET}/${key}" \
-              --content-type application/json --only-show-errors
-            echo "pinned 24.04 -> ${PIN_VERSION} in ${key}"
-          }
-
-          SKEL='{"$schema":"https://linux-dist.particle.io/schema/release_metadata_v1.json","builds":[]}'
-          pin_24_04 "$LATEST_KEY" require   # latest MUST exist; never seed/clobber
-          pin_24_04 "$STABLE_KEY" seed      # stable may not exist yet; seed if 404
-
+          aws s3 cp release_metadata.json \
+            "s3://${LINUX_DIST_S3_BUCKET}/${PREVIEW_KEY}" \
+            --content-type application/json --only-show-errors
+          echo "published 26.04 preview metadata -> ${PREVIEW_KEY}"
           if [ -n "${CF_DIST_ID:-}" ]; then
             aws cloudfront create-invalidation --distribution-id "$CF_DIST_ID" \
-              --paths "/${LATEST_KEY}" "/${STABLE_KEY}"
+              --paths "/${PREVIEW_KEY}"
           fi
 
-      - name: S3 metadata (dry run)
-        if: env.PUSH_JSON != 'true'
-        run: echo "PUSH_JSON != 'true' -- dry run, nothing pushed to S3."
+      - name: Preview metadata (dry run)
+        if: env.PUSH_26_04_JSON != 'true'
+        run: echo "PUSH_26_04_JSON != 'true' -- 26.04 preview manifest not published. 26.04 stays off served AND preview channels."

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ####################################################################################################################
-# Tachyon System Image Composer — 24.04 (new-BP / Quectel r108 / UEFI backend)
+# Tachyon System Image Composer — 26.04 (new-BP / Quectel r108 / UEFI backend)
 #
-# `make build_24.04` orchestrates: fetch components (24.04 base rootfs, bp-fw, kernel deb,
-# overlay tool + overlays) -> compose_24_04.sh (inside Docker) builds rootfs (+ overlay stack),
+# `make build_26.04` orchestrates: fetch components (26.04 base rootfs, bp-fw, kernel deb,
+# overlay tool + overlays) -> compose.sh (inside Docker) builds rootfs (+ overlay stack),
 # efi, dtb, nonhlos, SIGNS the boot/firmware blobs (selectable key), and assembles an
 # EDL-flashable image via ptool + partition_ext.
 #
@@ -50,7 +50,7 @@ endif
 # -------------------------------------------------------------------
 # Authoritative source versions (always read from versions.json)
 # -------------------------------------------------------------------
-VERSIONS_FILE ?= versions.json
+VERSIONS_FILE ?= versions-26.04.json
 # Read sources.<repo>.<field>, the env block, and the signing block from versions.json.
 # Strips `//` line-comments (lines starting with optional whitespace then //) before parsing,
 # preserving `//` inside values like https:// URLs.
@@ -62,7 +62,7 @@ _SIGN     = $(shell python3 -c "import json,re;t=re.sub(r'^\s*//.*$$','',open('$
 # onto every variant. Missing key -> empty.
 _ENV_JSON_KEY = $(shell python3 -c "import json,re;t=re.sub(r'^\s*//.*$$','',open('$(VERSIONS_FILE)').read(),flags=re.MULTILINE);e=json.loads(t).get('$(1)',{});print(','.join(f'{k}={v}' for k,v in e.items()))" 2>/dev/null)
 
-JSON_BASE24_PARAM       := $(call _SRC,particle-iot/tachyon-ubuntu-24.04,param)
+JSON_BASE_PARAM       := $(call _SRC,particle-iot/tachyon-ubuntu-26.04,param)
 JSON_OVERLAYS_PARAM     := $(call _SRC,particle-iot/tachyon-overlay,param)
 JSON_OVERLAY_TOOL_PARAM := $(call _SRC,particle-iot/tachyon-overlay-tool,param)
 ENV_FROM_JSON           := $(_ENV_JSON)
@@ -73,8 +73,8 @@ ifneq ($(strip $(ENV_FROM_JSON_VARIANT)),)
   ENV_FROM_JSON := $(if $(strip $(ENV_FROM_JSON)),$(ENV_FROM_JSON)$(comma),)$(ENV_FROM_JSON_VARIANT)
 endif
 
-ifneq ($(strip $(JSON_BASE24_PARAM)),)
-  INPUT_BASE_24_04_VERSION ?= $(JSON_BASE24_PARAM)
+ifneq ($(strip $(JSON_BASE_PARAM)),)
+  INPUT_BASE_VERSION ?= $(JSON_BASE_PARAM)
 endif
 ifneq ($(strip $(JSON_OVERLAYS_PARAM)),)
   override OVERLAYS_REF := $(JSON_OVERLAYS_PARAM)
@@ -89,13 +89,13 @@ endif
 COMMAND ?=
 INPUT_REGION ?=                     # NA | RoW
 INPUT_VARIANT ?=                    # headless | desktop  (headless == server)
-INPUT_BASE_24_04_VERSION ?=         # e.g., 22-938ac1d
+INPUT_BASE_VERSION ?=         # e.g., 22-938ac1d
 INPUT_ENV ?=
 INPUT_OVERLAY_PATH ?= $(DEFAULT_OVERLAY_PATH)
-OUTPUT_24_04_SYSTEM_IMAGE ?= $(DEFAULT_OUTPUT_PREFIX)-24.04-$(INPUT_REGION)-$(INPUT_VARIANT)-formfactor_dvt-$(OUTPUT_VERSION).zip
+OUTPUT_SYSTEM_IMAGE ?= $(DEFAULT_OUTPUT_PREFIX)-26.04-$(INPUT_REGION)-$(INPUT_VARIANT)-formfactor_dvt-$(OUTPUT_VERSION).zip
 
-# Channel for the 24.04 base image (release | prerelease | preproduction)
-BASE24_CHANNEL ?= release
+# Channel for the 26.04 base image (release | prerelease | preproduction)
+BASE_CHANNEL ?= release
 
 # Working variables
 TMP_ROOT_DIR ?= $(DEFAULT_TMP_ROOT_DIR)
@@ -103,8 +103,8 @@ TMP_INPUT_DIR ?= $(DEFAULT_TMP_INPUT_DIR)
 TMP_OUTPUT_DIR ?= $(DEFAULT_TMP_OUTPUT_DIR)
 INPUT_OVERLAY_DOCKER_PATH := $(strip /tmp/work/$(subst $(DEFAULT_TMP_ROOT_DIR)/,,$(INPUT_OVERLAY_PATH)))
 
-# overlay stack defaults to ubuntu-<variant>-24.04 unless INPUT_OVERLAY_STACK is set
-OVERLAY_STACK := $(if $(strip $(INPUT_OVERLAY_STACK)),$(INPUT_OVERLAY_STACK),ubuntu-$(INPUT_VARIANT)-24.04)
+# overlay stack defaults to ubuntu-<variant>-26.04 unless INPUT_OVERLAY_STACK is set
+OVERLAY_STACK := $(if $(strip $(INPUT_OVERLAY_STACK)),$(INPUT_OVERLAY_STACK),ubuntu-$(INPUT_VARIANT)-26.04)
 
 # -------------------------------------------------------------------
 # Signing (composer-owned, selectable key). See scripts/signing/ and keys/.
@@ -118,7 +118,7 @@ SIGNING_KEY     ?= $(call _SIGN,key)
 define check_required_param
 	@if [ -z "$($(1))" ]; then \
 		echo "Error: $(1) parameter is required"; \
-		echo "Usage: make build_24.04 VERSIONS_FILE=./versions.json INPUT_REGION=<NA|RoW> INPUT_VARIANT=<headless|desktop> [OUTPUT_VERSION=<x.y.z>]"; \
+		echo "Usage: make build_26.04 VERSIONS_FILE=./versions.json INPUT_REGION=<NA|RoW> INPUT_VARIANT=<headless|desktop> [OUTPUT_VERSION=<x.y.z>]"; \
 		exit 1; \
 	fi
 endef
@@ -133,21 +133,21 @@ define validate_variant
 		echo "Error: INPUT_VARIANT must be 'headless' or 'desktop', got '$(INPUT_VARIANT)'"; exit 1; fi
 endef
 
-define validate_output_24_04
-	@if [ -z "$(OUTPUT_24_04_SYSTEM_IMAGE)" ]; then \
-		echo "Error: OUTPUT_24_04_SYSTEM_IMAGE not set and no default provided."; exit 1; fi
+define validate_output
+	@if [ -z "$(OUTPUT_SYSTEM_IMAGE)" ]; then \
+		echo "Error: OUTPUT_SYSTEM_IMAGE not set and no default provided."; exit 1; fi
 endef
 
 # -------------------------------------------------------------------
 # Derived filenames/URLs
 # -------------------------------------------------------------------
-# 24.04 base .img.xz / .img (rootfs source). Variant in {headless,desktop}, both published.
-# Example: tachyon-ubuntu-24.04-headless-image-22-938ac1d.img.xz
-BASE24_XZ_FILENAME := tachyon-ubuntu-24.04-$(INPUT_VARIANT)-image-$(INPUT_BASE_24_04_VERSION).img.xz
-BASE24_URL := https://tachyon-ci.particle.io/$(BASE24_CHANNEL)/$(BASE24_XZ_FILENAME)
-BASE24_XZ := $(TMP_INPUT_DIR)/$(BASE24_XZ_FILENAME)
-BASE24_IMG := $(TMP_INPUT_DIR)/$(basename $(BASE24_XZ_FILENAME))
-BASE24_IMG_BASENAME := $(notdir $(BASE24_IMG))
+# 26.04 base .img.xz / .img (rootfs source). Variant in {headless,desktop}, both published.
+# Example: tachyon-ubuntu-26.04-headless-image-22-938ac1d.img.xz
+BASE_XZ_FILENAME := tachyon-ubuntu-26.04-$(INPUT_VARIANT)-image-$(INPUT_BASE_VERSION).img.xz
+BASE_URL := https://tachyon-ci.particle.io/$(BASE_CHANNEL)/$(BASE_XZ_FILENAME)
+BASE_XZ := $(TMP_INPUT_DIR)/$(BASE_XZ_FILENAME)
+BASE_IMG := $(TMP_INPUT_DIR)/$(basename $(BASE_XZ_FILENAME))
+BASE_IMG_BASENAME := $(notdir $(BASE_IMG))
 
 # bp-fw: referenced as an ARTIFACT ONLY (version + S3 url), never as a repo source.
 # The BP firmware repo must not be a versions.json dependency; the composer consumes
@@ -159,10 +159,10 @@ BP_FW_URL          := $(call _SRC,bp-fw,url)
 BOOTBINARIES_ZIP   := $(TMP_INPUT_DIR)/QCM6490_bootbinaries.zip
 
 # kernel modules deb (single-sourced from versions.json) -> qcm6490-tachyon.dtb
-KERNEL_TAG         := $(call _SRC,particle-iot/tachyon-ubuntu-24.04-kernel,param)
-KERNEL_ABI         := $(call _SRC,particle-iot/tachyon-ubuntu-24.04-kernel,abi)
-KERNEL_DEB_VERSION := $(call _SRC,particle-iot/tachyon-ubuntu-24.04-kernel,deb_version)
-KERNEL_BASE_URL    := $(call _SRC,particle-iot/tachyon-ubuntu-24.04-kernel,base_url)
+KERNEL_TAG         := $(call _SRC,particle-iot/tachyon-ubuntu-26.04-kernel,param)
+KERNEL_ABI         := $(call _SRC,particle-iot/tachyon-ubuntu-26.04-kernel,abi)
+KERNEL_DEB_VERSION := $(call _SRC,particle-iot/tachyon-ubuntu-26.04-kernel,deb_version)
+KERNEL_BASE_URL    := $(call _SRC,particle-iot/tachyon-ubuntu-26.04-kernel,base_url)
 
 KIGEN_SDK_TAG      := $(call _SRC,particle-iot-inc/kigen-sdk,param)
 KIGEN_SDK_ASSET    := $(call _SRC,particle-iot-inc/kigen-sdk,asset)
@@ -186,7 +186,7 @@ define PRINT_BANNER
 	@printf '%s\n' \
 	'**************************************************' \
 	'*                                                *' \
-	'*     Tachyon System Image (24.04 / new-BP)      *' \
+	'*     Tachyon System Image (26.04 / new-BP)      *' \
 	'*                                                *' \
 	'**************************************************'
 endef
@@ -196,7 +196,7 @@ define PRINT_CONFIG
 	@echo "Version Tag:       $(VERSION)"
 	@echo
 	@echo "Inputs (resolved)"
-	@echo "  24.04 Build ID:  $(INPUT_BASE_24_04_VERSION)  ($(BASE24_IMG_BASENAME))"
+	@echo "  26.04 Build ID:  $(INPUT_BASE_VERSION)  ($(BASE_IMG_BASENAME))"
 	@echo "  Region:          $(INPUT_REGION)   (nonhlos: $(NONHLOS_VARIANT))"
 	@echo "  Variant:         $(INPUT_VARIANT)"
 	@echo "  bp-fw URL:       $(BP_FW_URL)"
@@ -205,7 +205,7 @@ define PRINT_CONFIG
 	@echo "  Signing:         profile=$(SIGNING_PROFILE)  key=$(SIGNING_KEY)"
 	@echo
 	@echo "Output"
-	@echo "  System Image:    $(OUTPUT_24_04_SYSTEM_IMAGE)"
+	@echo "  System Image:    $(OUTPUT_SYSTEM_IMAGE)"
 	@echo "  Debug:           $(DEBUG)"
 	@echo "  Input Env:       $(if $(strip $(INPUT_ENV)),$(INPUT_ENV),<none>)"
 	@echo "**************************************************"
@@ -221,11 +221,11 @@ print-config:
 # -------------------------------------------------------------------
 .PHONY: help
 help:
-	@echo "Tachyon System Image Composer v$(VERSION) (24.04 / new-BP / UEFI)"
+	@echo "Tachyon System Image Composer v$(VERSION) (26.04 / new-BP / UEFI)"
 	@echo ""
 	@echo "Available commands:"
-	@echo "  build_24.04                 Build a Tachyon 24.04 EDL system image (new-BP)"
-	@echo "  fetch_24_04 / _unxz         Download / decompress the 24.04 base .img.xz"
+	@echo "  build_26.04                 Build a Tachyon 26.04 EDL system image (new-BP)"
+	@echo "  fetch_base / _unxz         Download / decompress the 26.04 base .img.xz"
 	@echo "  fetch_bp_fw                 Download bp-fw and split bootbinaries + fw zips"
 	@echo "  fetch_kernel_deb            Download the kernel modules deb (for qcm6490-tachyon.dtb)"
 	@echo "  fetch_kigen_sdk             Download the Kigen LPA binary (host-side; private repo)"
@@ -239,32 +239,32 @@ help:
 	@echo "  INPUT_VARIANT               headless (==server) or desktop"
 	@echo ""
 	@echo "Optional parameters:"
-	@echo "  VERSIONS_FILE               Path to versions.json (default: versions.json)"
+	@echo "  VERSIONS_FILE               Path to the versions file (default: versions-26.04.json)"
 	@echo "  OUTPUT_VERSION              Version stamped into the image (default: $(DEFAULT_OUTPUT_VERSION))"
 	@echo "  SIGNING_PROFILE             test | prod | none (default from versions.json signing.profile)"
 	@echo "  SIGNING_KEY                 key name under ./keys/ (default from versions.json signing.key)"
 	@echo "  INPUT_OVERLAY_DIR           Local overlays dir (skip cloning tachyon-overlays)"
-	@echo "  INPUT_OVERLAY_STACK         Overlay stack/branch (e.g., ubuntu-headless-24.04)"
+	@echo "  INPUT_OVERLAY_STACK         Overlay stack/branch (e.g., ubuntu-headless-26.04)"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make build_24.04 VERSIONS_FILE=./versions.json INPUT_REGION=RoW INPUT_VARIANT=headless OUTPUT_VERSION=1.2.0"
+	@echo "  make build_26.04 INPUT_REGION=RoW INPUT_VARIANT=headless OUTPUT_VERSION=1.3.0"
 	@echo ""
 
 # -------------------------------------------------------------------
-# Fetch: 24.04 base rootfs image
+# Fetch: 26.04 base rootfs image
 # -------------------------------------------------------------------
-.PHONY: fetch_24_04 fetch_24_04_unxz
-fetch_24_04: $(BASE24_XZ)
-$(BASE24_XZ): | docker/build
-	$(call check_required_param,INPUT_BASE_24_04_VERSION)
+.PHONY: fetch_base fetch_base_unxz
+fetch_base: $(BASE_XZ)
+$(BASE_XZ): | docker/build
+	$(call check_required_param,INPUT_BASE_VERSION)
 	$(call check_required_param,INPUT_VARIANT)
 	$(call validate_variant)
 	@$(DOCKER_RUN) bash -lc 'set -euo pipefail; mkdir -p "$(TMP_INPUT_DIR)"; \
-		echo "==> Downloading 24.04 base: $(BASE24_URL)"; \
-		curl $(CURL_OPTS) -o "$@" "$(BASE24_URL)"; test -s "$@"; echo "Downloaded: $@"'
+		echo "==> Downloading 26.04 base: $(BASE_URL)"; \
+		curl $(CURL_OPTS) -o "$@" "$(BASE_URL)"; test -s "$@"; echo "Downloaded: $@"'
 
-fetch_24_04_unxz: $(BASE24_IMG)
-$(BASE24_IMG): $(BASE24_XZ) | docker/build
+fetch_base_unxz: $(BASE_IMG)
+$(BASE_IMG): $(BASE_XZ) | docker/build
 	@$(DOCKER_RUN) bash -lc 'set -euo pipefail; cd "$(TMP_INPUT_DIR)"; \
 		if [ -f "$(notdir $@)" ]; then echo "$(notdir $@) exists, skipping"; exit 0; fi; \
 		echo "==> Decompressing $(notdir $<)"; \
@@ -422,23 +422,23 @@ fetch_tachyon_overlays: | docker/build
 # -------------------------------------------------------------------
 # Main build
 # -------------------------------------------------------------------
-.PHONY: build_24.04
-build_24.04: version print-config check_qemu vendor_sectools fetch_24_04_unxz fetch_bp_fw fetch_kernel_deb fetch_kigen_sdk fetch_overlay_tool fetch_tachyon_overlays docker/build
-	@echo "Building Tachyon 24.04 (new-BP) System Image..."
+.PHONY: build_26.04
+build_26.04: version print-config check_qemu vendor_sectools fetch_base_unxz fetch_bp_fw fetch_kernel_deb fetch_kigen_sdk fetch_overlay_tool fetch_tachyon_overlays docker/build
+	@echo "Building Tachyon 26.04 (new-BP) System Image..."
 	$(call check_required_param,INPUT_REGION)
 	$(call check_required_param,INPUT_VARIANT)
-	$(call check_required_param,INPUT_BASE_24_04_VERSION)
+	$(call check_required_param,INPUT_BASE_VERSION)
 	$(call validate_region)
 	$(call validate_variant)
-	$(call validate_output_24_04)
-	$(eval GENERATED_DISTRO_ENV := PKG_DISTRO_VERSION=$(OUTPUT_VERSION)$(comma)PKG_DISTRO_STACK=$(OVERLAY_STACK)$(comma)PKG_DISTRO_VARIANT=$(INPUT_VARIANT)$(comma)PKG_DISTRO_REGION=$(INPUT_REGION)$(comma)PKG_DISTRO_BOARD=formfactor_dvt$(comma)PKG_DISTRO_DISTRIBUTION=ubuntu$(comma)PKG_DISTRO_DISTRIBUTION_VERSION=24.04)
-	$(eval GENERATED_SRC_ENV := PKG_SRC_TACHYON_COMPOSER=$(VERSION)$(comma)PKG_SRC_UBUNTU_24_04=$(INPUT_BASE_24_04_VERSION)$(comma)PKG_SRC_OVERLAYS=$(OVERLAYS_REF))
+	$(call validate_output)
+	$(eval GENERATED_DISTRO_ENV := PKG_DISTRO_VERSION=$(OUTPUT_VERSION)$(comma)PKG_DISTRO_STACK=$(OVERLAY_STACK)$(comma)PKG_DISTRO_VARIANT=$(INPUT_VARIANT)$(comma)PKG_DISTRO_REGION=$(INPUT_REGION)$(comma)PKG_DISTRO_BOARD=formfactor_dvt$(comma)PKG_DISTRO_DISTRIBUTION=ubuntu$(comma)PKG_DISTRO_DISTRIBUTION_VERSION=26.04)
+	$(eval GENERATED_SRC_ENV := PKG_SRC_TACHYON_COMPOSER=$(VERSION)$(comma)PKG_SRC_UBUNTU_26_04=$(INPUT_BASE_VERSION)$(comma)PKG_SRC_OVERLAYS=$(OVERLAYS_REF))
 	$(eval GENERATED_ENV := $(GENERATED_DISTRO_ENV)$(comma)$(GENERATED_SRC_ENV))
 	$(eval COMBINED_ENV := $(if $(strip $(INPUT_ENV)),$(INPUT_ENV)$(comma),)$(GENERATED_ENV))
 	@mkdir -p $(TMP_INPUT_DIR) $(TMP_OUTPUT_DIR)
-	@$(DOCKER_RUN) bash ./compose_24_04.sh \
-		"$(BASE24_IMG_BASENAME)" \
-		"$(OUTPUT_24_04_SYSTEM_IMAGE)" \
+	@$(DOCKER_RUN) bash ./compose.sh \
+		"$(BASE_IMG_BASENAME)" \
+		"$(OUTPUT_SYSTEM_IMAGE)" \
 		"$(NONHLOS_VARIANT)" \
 		"$(OVERLAY_STACK)" \
 		"$(INPUT_OVERLAY_DOCKER_PATH)" \
@@ -448,7 +448,7 @@ build_24.04: version print-config check_qemu vendor_sectools fetch_24_04_unxz fe
 		"$(SIGNING_KEY)"
 	@echo ""
 	@echo "Build completed successfully!"
-	@echo "Output: $(abspath $(TMP_OUTPUT_DIR))/$(OUTPUT_24_04_SYSTEM_IMAGE)"
+	@echo "Output: $(abspath $(TMP_OUTPUT_DIR))/$(OUTPUT_SYSTEM_IMAGE)"
 
 ##########################################################
 # Docker-related targets
@@ -465,6 +465,8 @@ DOCKER_VERSION ?= $(if $(PARTICLE_DOCKERFILE_VERSION),$(PARTICLE_DOCKERFILE_VERS
 
 IMAGE_NAME           ?= tachyon-system-image-builder
 IMAGE_TAG            ?= $(IMAGE_NAME):$(DOCKER_VERSION)
+# Builder toolchain OS (ptool/sectools/qemu), NOT the target series: the composer
+# only assembles an already-built 26.04 rootfs, so 24.04 is a fine, proven builder.
 BASE_IMAGE           ?= ubuntu:24.04
 UID                  ?= $(shell id -u 2>/dev/null || echo 1000)
 GID                  ?= $(shell id -g 2>/dev/null || echo 1000)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
-# Tachyon System Image Composer (24.04 / new-BP)
+# Tachyon System Image Composer (26.04 / new-BP)
 
-A build system that composes flashable **Tachyon Ubuntu 24.04** EDL system images for the
-QCM6490 (Quectel r108 baseband) platform. It takes a 24.04 base rootfs, the new BP firmware
+> **This is the `26.04` branch.** It builds **Tachyon Ubuntu 26.04** only. The 24.04
+> composer lives on `main`; the two are kept apart on purpose (26.04 is the less-common
+> track). Pull shared fixes in with `git merge main`.
+>
+> **Versioning:** 26.04 has its own version line (**1.3.x**), independent of 24.04's 1.2.x.
+> Because git tags are repo-global, **release tags on this branch MUST be namespaced
+> `26.04/x.y.z`** (e.g. `26.04/1.3.0`) — a bare `x.y.z` tag would pollute 24.04's version
+> stream on `main`. CI resolves the version via `tachyon-resolve-version --tag-prefix
+> "26.04/"` (see `.github/workflows/build.yml`). 26.04 **never** writes the served OTA
+> channels (latest/stable); it only publishes prerelease artifacts and, when explicitly
+> enabled, an un-served preview manifest.
+
+A build system that composes flashable **Tachyon Ubuntu 26.04** EDL system images for the
+QCM6490 (Quectel r108 baseband) platform. It takes a 26.04 base rootfs, the new BP firmware
 artifact, and a kernel device tree, applies an overlay stack, **signs the boot/firmware blobs
 itself with a selectable key**, and assembles an EDL-flashable image.
 
 Boot chain: **XBL → UEFI (from bp-fw) → GRUB → Linux**. There is no Ubuntu 20.04 base, no
 U-Boot, and no `qtestsign` — that legacy path has been retired.
+
+> **Kernel note:** there is no `linux-qcom` kernel for resolute (26.04), so 26.04 ships the
+> same Particle 6.8 kernel as 24.04 (built by `tachyon-ubuntu-24.04-kernel`; the noble deb
+> installs cleanly on a resolute rootfs). Pins live in `versions-26.04.json`.
 
 For background, see the
 [Particle Tachyon Ubuntu 24.04 Overview](https://developer.particle.io/tachyon/software/ubuntu_24_04/overview).
@@ -30,16 +46,16 @@ For background, see the
 
 ```bash
 # Build RoW / headless at version 1.2.0
-make build_24.04 \
-  VERSIONS_FILE=./versions.json \
+make build_26.04 \
+  VERSIONS_FILE=./versions-26.04.json \
   INPUT_REGION=RoW \
   INPUT_VARIANT=headless \
   OUTPUT_VERSION=1.2.0
 ```
 
 `VERSIONS_FILE` is the authoritative source of component versions; the four required inputs
-(`INPUT_REGION`, `INPUT_VARIANT`, and the 24.04 build id + overlay/signing config from
-`versions.json`) drive the rest. Override any value on the `make` line.
+(`INPUT_REGION`, `INPUT_VARIANT`, and the 26.04 build id + overlay/signing config from
+`versions-26.04.json`) drive the rest. Override any value on the `make` line.
 
 The full release matrix is `{NA, RoW} × {headless, desktop}` — build all four for a release.
 
@@ -47,26 +63,26 @@ The full release matrix is `{NA, RoW} × {headless, desktop}` — build all four
 
 ## ⚙️ Parameters
 
-All parameters are `make` variables (`make build_24.04 VAR=value …`).
+All parameters are `make` variables (`make build_26.04 VAR=value …`).
 
 ### Required
 | Variable | Values | Notes |
 |---|---|---|
 | `INPUT_REGION` | `NA` \| `RoW` | Selects the region NON-HLOS firmware (`na`/`em`). |
 | `INPUT_VARIANT` | `headless` \| `desktop` | `headless` == server. Selects the base image + default overlay stack. |
-| `VERSIONS_FILE` | path | Source of truth for versions/signing/env. Default `versions.json`. |
-| `INPUT_BASE_24_04_VERSION` | e.g. `22-938ac1d` | 24.04 base build id. Defaults from `versions.json` (`tachyon-ubuntu-24.04.param`). |
+| `VERSIONS_FILE` | path | Source of truth for versions/signing/env. Default `versions-26.04.json`. |
+| `INPUT_BASE_VERSION` | e.g. `22-938ac1d` | 26.04 base build id. Defaults from `versions-26.04.json` (`tachyon-ubuntu-26.04.param`). |
 
 ### Optional
 | Variable | Default | Notes |
 |---|---|---|
 | `OUTPUT_VERSION` | `9.9.999` | Version stamped into the image/zip name. Set explicitly per build (e.g. `1.2.0`). |
-| `OUTPUT_24_04_SYSTEM_IMAGE` | derived | `tachyon-ubuntu-24.04-<region>-<variant>-formfactor_dvt-<version>.zip`. |
-| `SIGNING_PROFILE` | `test` (from `versions.json` `signing.profile`) | `test` \| `prod` \| `none`. See [Signing](#-signing). |
-| `SIGNING_KEY` | from `versions.json` `signing.key` | Key name under `./keys/` (for `test`). |
-| `INPUT_OVERLAY_STACK` | `ubuntu-<variant>-24.04` | Overlay stack to apply. |
-| `INPUT_ENV` | from `versions.json` `env` block | Comma-separated `KEY=VAL` passed to the overlay tool (package pins, `PIN_PRIORITY`, …). |
-| `BASE24_CHANNEL` | `release` | `release` \| `prerelease` \| `preproduction` — channel for the 24.04 base image. |
+| `OUTPUT_SYSTEM_IMAGE` | derived | `tachyon-ubuntu-26.04-<region>-<variant>-formfactor_dvt-<version>.zip`. |
+| `SIGNING_PROFILE` | `test` (from `versions-26.04.json` `signing.profile`) | `test` \| `prod` \| `none`. See [Signing](#-signing). |
+| `SIGNING_KEY` | from `versions-26.04.json` `signing.key` | Key name under `./keys/` (for `test`). |
+| `INPUT_OVERLAY_STACK` | `ubuntu-<variant>-26.04` | Overlay stack to apply. |
+| `INPUT_ENV` | from `versions-26.04.json` `env` block | Comma-separated `KEY=VAL` passed to the overlay tool (package pins, `PIN_PRIORITY`, …). |
+| `BASE_CHANNEL` | `release` | `release` \| `prerelease` \| `preproduction` — channel for the 26.04 base image. |
 | `DEBUG` | `false` | `true` enables `set -x` verbose tracing in the compose script. |
 | `TMP_INPUT_DIR` / `TMP_OUTPUT_DIR` / `TMP_ROOT_DIR` | `./.tmp/...` | Working directories. |
 
@@ -76,7 +92,7 @@ All parameters are `make` variables (`make build_24.04 VAR=value …`).
 
 ---
 
-## 📄 `versions.json`
+## 📄 `versions-26.04.json`
 
 The authoritative inputs. Supports `//` line comments.
 
@@ -87,12 +103,12 @@ The authoritative inputs. Supports `//` line comments.
     // repo dependency. Ships bootbinaries, QCM6490 fw, and pre-built region NON-HLOS images.
     "bp-fw": { "version": "2.0.3", "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.3.zip" },
 
-    // 24.04 base rootfs (livecd-rootfs). Variants headless (==server) and desktop both published.
-    "particle-iot/tachyon-ubuntu-24.04": { "type": "git_release", "param": "22-938ac1d" },
+    // 26.04 base rootfs (livecd-rootfs). Variants headless (==server) and desktop both published.
+    "particle-iot/tachyon-ubuntu-26.04": { "type": "git_release", "param": "22-938ac1d" },
 
     // Kernel input (single source of truth) — provides qcm6490-tachyon.dtb AND pins the rootfs
     // kernel. MUST match PKG_linux_particle in env and the base image ABI.
-    "particle-iot/tachyon-ubuntu-24.04-kernel": {
+    "particle-iot/tachyon-ubuntu-26.04-kernel": {
       "type": "s3_release", "param": "stable-6.8.0-1058.59particle2",
       "abi": "1058", "deb_version": "6.8.0-1058.59+particle2",
       "base_url": "https://linux-dist.particle.io/kernel/release"
@@ -117,7 +133,7 @@ The authoritative inputs. Supports `//` line comments.
 }
 ```
 
-The BP firmware repo is **never** a `versions.json` dependency — only its published artifact zip
+The BP firmware repo is **never** a `versions-26.04.json` dependency — only its published artifact zip
 (`url` + `version`) is consumed.
 
 ---
@@ -142,25 +158,25 @@ re-signed hashes (it vouches for 10 boot blobs + ADSP/CDSP/WPSS from `QCM6490_fw
 
 ---
 
-## 🔄 Build Pipeline (`compose_24_04.sh`, in Docker)
+## 🔄 Build Pipeline (`compose.sh`, in Docker)
 
-1. **rootfs.ext4** — built from the 24.04 base `.img`, sized with headroom.
-2. **Overlay stack** — `tachyon-overlay-tool` applies `ubuntu-<variant>-24.04` (packages,
+1. **rootfs.ext4** — built from the 26.04 base `.img`, sized with headroom.
+2. **Overlay stack** — `tachyon-overlay-tool` applies `ubuntu-<variant>-26.04` (packages,
    Particle services, kernel pin) using the `INPUT_ENV` pins.
 3. **efi.img** — GRUB ESP (`scripts/efi/make-efi-img.sh`).
 4. **dtb.img** — `qcm6490-tachyon.dtb` extracted from the kernel modules deb (`scripts/dtb/`).
 5. **nonhlos.img** — region firmware (`em`/`na`), shipped pre-built in the bp-fw artifact.
 6. **Sign** — `scripts/signing/sign.sh` re-signs the boot/fw blobs + regenerates `multi_image.mbn`.
 7. **Assemble** — `scripts/assemble/` (ptool + `partition_ext.xml`) produces `rawprogram*/patch*`.
-8. **Package** — `manifest.json` + zip → `.tmp/output/<OUTPUT_24_04_SYSTEM_IMAGE>`.
+8. **Package** — `manifest.json` + zip → `.tmp/output/<OUTPUT_SYSTEM_IMAGE>`.
 
 ---
 
 ## 🛠 Commands
 
 ```
-build_24.04                Build a Tachyon 24.04 EDL system image (new-BP)
-fetch_24_04 / _unxz        Download / decompress the 24.04 base .img.xz
+build_26.04                Build a Tachyon 26.04 EDL system image (new-BP)
+fetch_base / _unxz        Download / decompress the 26.04 base .img.xz
 fetch_bp_fw                Download bp-fw and split bootbinaries + fw + nonhlos images
 fetch_kernel_deb           Download the kernel modules deb (for qcm6490-tachyon.dtb)
 fetch_overlay_tool         Clone tachyon-overlay-tool inside Docker
@@ -180,10 +196,10 @@ help                       Full command + parameter list
 ## 📂 Repository Layout
 
 ```
-compose_24_04.sh        Core composition (runs in Docker)
+compose.sh        Core composition (runs in Docker)
 prepare_base_24.04.sh   Base staging helper
 Makefile                Orchestrator: fetch, validate, signing/matrix plumbing
-versions.json           Authoritative component versions + signing + env
+versions-26.04.json           Authoritative component versions + signing + env
 Dockerfile              Ubuntu 24.04 builder image
 keys/                   Signing keys (TEST keys only — see keys/README.md)
 scripts/

--- a/compose.sh
+++ b/compose.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
-# Tachyon System Image Composer – 24.04 (new-BP / Quectel r108 / UEFI backend)
+# Tachyon System Image Composer – 26.04 (new-BP / Quectel r108 / UEFI backend)
 # -----------------------------------------------------------------------------
 # Runs inside the builder container (-w /project, /tmp/work = ./.tmp).
 #
 # Builds an EDL-flashable factory image:
-#   1) rootfs.ext4 from the 24.04 base .img (composer's normal rootfs)
+#   1) rootfs.ext4 from the 26.04 base .img (composer's normal rootfs)
 #   2) efi.img from the vendored GRUB ESP
 #   3) apply the tachyon-overlays stack to rootfs.ext4 (installs kernel, etc.)
 #   4) dtb.img (qcm6490-tachyon.dtb) + nonhlos-<variant>.img
@@ -19,7 +19,7 @@
 # scripts/signing/ with a selectable key (see scripts/signing/README.md, keys/).
 #
 # Inputs placed by the Makefile fetch targets under /tmp/work/input:
-#   <BASE24_IMG_BASENAME>            24.04 base .img (rootfs source)
+#   <BASE_IMG_BASENAME>            26.04 base .img (rootfs source)
 #   QCM6490_bootbinaries.zip         bp-fw boot binaries (sign-ready when built from feature/nosign)
 #   kernel/linux-modules-*.deb       kernel deb (for qcm6490-tachyon.dtb)
 # Tools cloned under /tmp/work/tools: tachyon-overlay-tool (+ overlays at $5).
@@ -27,7 +27,7 @@
 # (nonhlos-<variant>.img is shipped pre-built by the bp-fw artifact, not built here)
 #
 # Args:
-#   $1 BASE24_IMG_BASENAME   $2 OUTPUT_ZIP   $3 NONHLOS_VARIANT(em|na)
+#   $1 BASE_IMG_BASENAME   $2 OUTPUT_ZIP   $3 NONHLOS_VARIANT(em|na)
 #   $4 OVERLAY_STACK         $5 OVERLAY_PATH (container path, has overlays/+stacks/)
 #   $6 OVERLAY_ENV (comma KEY=VAL)   $7 DEBUG(true|false)
 #   $8 SIGNING_PROFILE(test|prod|none)   $9 SIGNING_KEY (key name under keys/)
@@ -39,7 +39,7 @@ IN=/tmp/work/input
 OUT=/tmp/work/output
 OVERLAY_TOOL_DIR=/tmp/work/tools/tachyon-overlay-tool
 
-BASE24="${1:?BASE24_IMG_BASENAME}"
+BASE_IMG_BASENAME="${1:?BASE_IMG_BASENAME}"
 OUTPUT_ZIP="${2:?OUTPUT_ZIP}"
 NONHLOS_VARIANT="${3:?NONHLOS_VARIANT}"
 OVERLAY_STACK="${4:?OVERLAY_STACK}"
@@ -140,9 +140,9 @@ content_gate(){
 mkdir -p "$OUT"
 work="$(mktemp -d)"
 
-# ---- 1) rootfs.ext4 from the 24.04 base img ---------------------------------
-section "1) rootfs.ext4 from 24.04 base ($BASE24)"
-IMG="$IN/$BASE24"
+# ---- 1) rootfs.ext4 from the 26.04 base img ---------------------------------
+section "1) rootfs.ext4 from 26.04 base ($BASE_IMG_BASENAME)"
+IMG="$IN/$BASE_IMG_BASENAME"
 [ -f "$IMG" ] || { echo "ERROR: missing $IMG" >&2; exit 1; }
 
 ROOT_MNT="$work/root"; mkdir -p "$ROOT_MNT"
@@ -287,7 +287,7 @@ for kv in env.split(','):
 
 # Authoritative metadata comes from the PKG_DISTRO_* env the Makefile injects (region/variant/
 # board/version). The zip NAME is not reliable to parse: release names are
-# tachyon-ubuntu-24.04-<region>-<variant>-<version>.zip (no board), and a clean semver version
+# tachyon-ubuntu-26.04-<region>-<variant>-<version>.zip (no board), and a clean semver version
 # like 1.2.0 has no dashes -- the old 4-field regex only matched dev versions whose dashes
 # happened to fill the 4th group, and errored on real releases. Parse the name (board optional)
 # only as a fallback when the env is absent.
@@ -296,7 +296,7 @@ variant = envd.get('PKG_DISTRO_VARIANT')
 board   = envd.get('PKG_DISTRO_BOARD') or 'formfactor_dvt'
 version = envd.get('PKG_DISTRO_VERSION')
 if not (region and variant and version):
-    m = re.match(r'tachyon-ubuntu-24\.04-(NA|RoW)-(headless|desktop)(?:-([^-]+))?-(.+)\.zip$', output_zip)
+    m = re.match(r'tachyon-ubuntu-26\.04-(NA|RoW)-(headless|desktop)(?:-([^-]+))?-(.+)\.zip$', output_zip)
     if not m:
         sys.exit("ERROR: cannot derive region/variant/version from PKG_DISTRO_* env or name %s" % output_zip)
     region  = region  or m.group(1)
@@ -305,7 +305,7 @@ if not (region and variant and version):
     version = version or m.group(4)
 
 src_map = [
-    ('ubuntu-24.04', 'PKG_SRC_UBUNTU_24_04'),
+    ('ubuntu-26.04', 'PKG_SRC_UBUNTU_26_04'),
     ('linux-particle', 'PKG_linux_particle'),
     ('particle-linux', 'PKG_particle_linux'),
     ('particle-tachyon-desktop-setup', 'PKG_particle_tachyon_desktop_setup'),
@@ -331,7 +331,7 @@ manifest = {
     'release_name': output_zip[:-4] if output_zip.endswith('.zip') else output_zip,
     'version': version, 'region': region, 'variant': variant,
     'platform': 'qcm6490', 'board': board, 'os': 'linux',
-    'distribution': 'ubuntu', 'distribution_version': '24.04', 'distribution_variant': 'ubuntu',
+    'distribution': 'ubuntu', 'distribution_version': '26.04', 'distribution_variant': 'ubuntu',
     'sources': sources,
     'targets': [{'qcm6490': {'edl': {
         'base': '.', 'firehose': firehose,

--- a/scripts/verify_zip.sh
+++ b/scripts/verify_zip.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# verify_zip.sh — sanity-check a composed Tachyon system image zip without hardware.
+#
+# Usage: scripts/verify_zip.sh <image.zip> <series> <region> <variant>
+#   e.g. scripts/verify_zip.sh .tmp/26.04/output/tachyon-ubuntu-26.04-RoW-headless-formfactor_dvt-9.9.999.zip 26.04 RoW headless
+#
+# Checks (zip-level; mounting rootfs.ext4 for content checks needs `make docker/shell`):
+#   - manifest.json present, fields match series/region/variant, firehose + XML lists set
+#   - sources[] carries the ubuntu-<series> base build id
+#   - every filename referenced by rawprogram*.xml exists in the zip
+#   - every referenced file fits its declared partition span
+set -euo pipefail
+
+ZIP="${1:?usage: verify_zip.sh <image.zip> <series> <region> <variant>}"
+SERIES="${2:?series (24.04|26.04)}"
+REGION="${3:?region (NA|RoW)}"
+VARIANT="${4:?variant (headless|desktop)}"
+
+test -s "$ZIP" || { echo "ERROR: $ZIP missing/empty" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+unzip -q "$ZIP" -d "$WORK"
+
+python3 - "$WORK" "$SERIES" "$REGION" "$VARIANT" <<'PY'
+import json, os, re, sys
+import xml.etree.ElementTree as ET
+
+root, series, region, variant = sys.argv[1:5]
+fail = []
+
+def check(cond, msg):
+    (print("OK  " + msg) if cond else fail.append(msg))
+    if not cond: print("FAIL " + msg)
+
+mpath = os.path.join(root, 'manifest.json')
+check(os.path.isfile(mpath), 'manifest.json present')
+m = json.load(open(mpath))
+
+check(m.get('distribution') == 'ubuntu', 'distribution == ubuntu')
+check(m.get('distribution_version') == series, f'distribution_version == {series} (got {m.get("distribution_version")})')
+check(m.get('region') == region, f'region == {region} (got {m.get("region")})')
+check(m.get('variant') == variant, f'variant == {variant} (got {m.get("variant")})')
+check(m.get('platform') == 'qcm6490', 'platform == qcm6490')
+
+srcs = {s['key']: s['value'] for s in m.get('sources', [])}
+base_key = 'ubuntu-' + series
+check(base_key in srcs and srcs[base_key], f'sources[] has {base_key} (base build id: {srcs.get(base_key)})')
+
+edl = m['targets'][0]['qcm6490']['edl']
+check(bool(edl.get('program_xml')), 'program_xml list non-empty')
+check(bool(edl.get('patch_xml')), 'patch_xml list non-empty')
+firehose = edl.get('firehose', '')
+check(os.path.isfile(os.path.join(root, firehose)), f'firehose present ({firehose})')
+
+# rawprogram*.xml: every referenced file exists and fits its partition span.
+missing, oversize, nfiles = [], [], 0
+for xmlname in edl['program_xml']:
+    tree = ET.parse(os.path.join(root, xmlname))
+    for p in tree.getroot().iter('program'):
+        fn = (p.get('filename') or '').strip()
+        if not fn:
+            continue
+        nfiles += 1
+        fp = os.path.join(root, fn)
+        if not os.path.isfile(fp):
+            missing.append(f'{fn} (from {xmlname})')
+            continue
+        try:
+            sectors = int(p.get('num_partition_sectors'))
+            ssize = int(p.get('SECTOR_SIZE_IN_BYTES'))
+        except (TypeError, ValueError):
+            continue
+        span = sectors * ssize
+        # sparse=true images are written expanded; compare against the span anyway
+        if os.path.getsize(fp) > span:
+            oversize.append(f'{fn}: {os.path.getsize(fp)} > {span} ({xmlname})')
+check(not missing, 'all rawprogram-referenced files present' + ('' if not missing else ': MISSING ' + ', '.join(missing)))
+check(not oversize, 'all files fit their partition spans' + ('' if not oversize else ': ' + '; '.join(oversize)))
+print(f'.. {nfiles} partition file references checked')
+
+if fail:
+    print(f'\n{len(fail)} check(s) FAILED', file=sys.stderr)
+    sys.exit(1)
+print('\nAll zip-level checks passed.')
+PY

--- a/versions-26.04.json
+++ b/versions-26.04.json
@@ -1,0 +1,97 @@
+{
+  "sources": {
+    // New BP firmware (Quectel r108) — same artifact as the 24.04 builds; the boot chain is
+    // series-independent. See versions-24.04.json for the full history notes. Keep the two
+    // series on the same bp-fw unless there is a series-specific reason not to: the fetch
+    // inputs are cached per-series (TMP dirs are series-scoped) so divergence is safe, just
+    // usually pointless.
+    "bp-fw": {
+      "version": "2.0.5",
+      "url": "https://tachyon-ci.particle.io/release/tachyon-bp-fw-2.0.5.zip"
+    },
+
+    // The 26.04 base rootfs image (built by particle-iot/tachyon-ubuntu-26.04 via livecd-rootfs,
+    // resolute). Consumed as tachyon-ubuntu-26.04-<VARIANT>-image-<param>.img.xz from the
+    // release channel. Variants: headless (== server) and desktop.
+    // First published 26.04 base build (release channel), from particle-iot/tachyon-ubuntu-26.04
+    // run on main: headless 1.26 GB + desktop 3.1 GB live at
+    // linux-dist.particle.io/release/tachyon-ubuntu-26.04-<variant>-image-29-29469e9.img.xz.
+    // The Makefile prepends "image-" to build the filename, so this is the BARE build id
+    // (<count>-<sha>), matching 24.04's convention (e.g. "26-0519f5b"). Bump when a newer
+    // base image is published. During bring-up override on the CLI:
+    // BASE_CHANNEL=prerelease INPUT_BASE_VERSION=<pre-sha id without the "image-" prefix>.
+    "particle-iot/tachyon-ubuntu-26.04": {
+      "type": "git_release",
+      "param": "29-29469e9"
+    },
+
+    // Kernel input. There is NO linux-qcom kernel line for resolute (26.04) — Canonical's
+    // QCS6490-era Qualcomm kernel exists only for noble — so 26.04 images ship the SAME
+    // Particle 6.8 kernel as 24.04 (built by particle-iot/tachyon-ubuntu-24.04-kernel; the
+    // noble-built deb installs cleanly on a resolute rootfs). The key here is series-templated
+    // for the Makefile lookup; the coordinates intentionally match versions-24.04.json.
+    // MUST stay in lock-step with env.PKG_linux_particle below and the kernel baked into the
+    // 26.04 base image, or check-pinned-packages will fail.
+    "particle-iot/tachyon-ubuntu-26.04-kernel": {
+      "type": "s3_release",
+      "param": "stable-6.8.0-1058.59particle6",
+      "abi": "1058",
+      // keep this equal to env.PKG_linux_particle below
+      "deb_version": "6.8.0-1058.59+particle6",
+      "base_url": "https://linux-dist.particle.io/kernel/release"
+    },
+
+    // Overlay stack repo. Pinned to a full 40-char commit sha (see versions-24.04.json for why).
+    // TODO: bump to the sha that carries the ubuntu-{common,headless,desktop}-26.04 stacks
+    // once feature/ubuntu-26.04-stacks merges — the current pin predates them and a 26.04
+    // build will fail at overlay stack resolution until this is bumped.
+    "particle-iot/tachyon-overlay": {
+      "type": "git_release",
+      "param": "4bbd8a8947f30862f66c4d4faf4eac9a2c67da31"
+    },
+
+    // The overlay TOOL — same pin as 24.04 (series-independent engine).
+    "particle-iot/tachyon-overlay-tool": {
+      "type": "git_release",
+      "param": "0b5f8fb597a8ba17e6e7035a0ca13d16ef29599c"
+    },
+
+    // The Kigen LPA (eSIM local profile assistant) — same asset as 24.04.
+    "particle-iot-inc/kigen-sdk": {
+      "type": "git_release",
+      "param": "0.1.8",
+      "asset": "lpa-linux-arm64"
+    }
+  },
+
+  // Signing — identical to 24.04; the boot chain and signer do not vary by series.
+  "signing": {
+    "profile": "test",
+    "key": "qti_presigned_certs-key2048_exp257_hashSHA384"
+  },
+
+  "env": {
+    // Kernel version pinned INSIDE the rootfs by the overlay. MUST equal the kernel source
+    // deb_version above and be installable on the base image's ABI. Shared with 24.04 — no
+    // resolute kernel line exists (see the kernel source comment above).
+    "PKG_linux_particle": "6.8.0-1058.59+particle6",
+
+    //This is the particle debian package
+    "PKG_particle_linux": "0.25.1-1",
+
+    //Radio code (RIL)
+    "PKG_particle_tachyon_ril": "0.6.1-1",
+
+    //The syscon package
+    "PKG_particle_tachyon_syscon": "1.0.52-1",
+
+    //version used in the debian file to pin the version down
+    "PIN_PRIORITY": "900"
+  },
+
+  // Variant-only pins (see versions-24.04.json).
+  "env_desktop": {
+    //Version of the setup app being used
+    "PKG_particle_tachyon_desktop_setup": "2.7.0"
+  }
+}


### PR DESCRIPTION
Dedicated 26.04 branch (fork pattern), forked cleanly from main so main stays 24.04-only and untouched. 26.04 is the less-common track; keeping it on its own branch avoids doubling mainline CI and coupling the two series. Supersedes the abandoned feature/dual-series-26.04 (which parameterised main to build both).

Minimal 26.04 specialisation, no dual-build machinery:
- Makefile: base image tachyon-ubuntu-26.04[-kernel], overlay stack ubuntu-<variant>-26.04, PKG_DISTRO_DISTRIBUTION_VERSION=26.04, PKG_SRC_UBUNTU_26_04, VERSIONS_FILE=versions-26.04.json, build_26.04 target, neutral names (INPUT_BASE_VERSION/OUTPUT_SYSTEM_IMAGE/BASE_*). Builder image stays ubuntu:24.04 (toolchain OS, not the target series).
- compose_24_04.sh -> compose.sh: manifest distribution_version/regex/src_map -> 26.04.
- versions-26.04.json: base image param 29-29469e9 (bare id; the Makefile prepends "image-"), shared noble 6.8 kernel, 26.04 overlay stacks, ril 0.6.1-1.
- verify_zip.sh: hardware-free zip checks.
- Workflow (26.04-only): region x variant matrix (no series axis); version via --tag-prefix 26.04/ --seed-version 1.3.0; release only on 26.04/x.y.z tags; DIST_TOOLS_VERSION 1.0.4; NEVER writes served OTA channels -- GitHub Release + an un-served preview manifest (PUSH_26_04_JSON, default false) only.

Verified locally: print-config + make -n resolve 26.04 base image (tachyon-ubuntu-26.04-<variant>-image-29-29469e9), overlay stack, kernel; base image reachable (HTTP 200) at the composer's fetch host.

Requires tachyon-dist-tools 1.0.4 (--tag-prefix); [skip ci] until it is released. Main's other files (FLASHING.md, xml_tools.py, etc.) are intentionally preserved for clean main->26.04 merges.


Claude-Session: https://claude.ai/code/session_01MZi46SafMwLuvLzh3Mm4Vs