### PR TITLE
versions: kernel 6.8.0-1058.59+particle7, 24.04 base image-27 (SECURITY: CVE-2026 IPsec/skb family)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -21,11 +21,11 @@
     // The 24.04 base rootfs image (built by particle-iot/tachyon-ubuntu-24.04 via livecd-rootfs).
     // Consumed as tachyon-ubuntu-24.04-<VARIANT>-image-<param>.img.xz from the release channel.
     // Variants: headless (== server) and desktop, both published.
-    // 26-0519f5b was rebuilt against the latest particle kernel, so it already carries
-    // linux-particle 6.8.0-1058.59+particle6 — matching the kernel pinned below.
+    // 27-7f5af3d was rebuilt against the latest particle kernel, so it already carries
+    // linux-particle 6.8.0-1058.59+particle7 — matching the kernel pinned below.
     "particle-iot/tachyon-ubuntu-24.04": {
       "type": "git_release",
-      "param": "26-0519f5b"
+      "param": "27-7f5af3d"
     },
 
     // Kernel input (single source of truth for the kernel line). Unlike main — where this was the
@@ -36,10 +36,10 @@
     // will fail.  <-- deb_version == env.PKG_linux_particle (see below)
     "particle-iot/tachyon-ubuntu-24.04-kernel": {
       "type": "s3_release",
-      "param": "stable-6.8.0-1058.59particle6",
+      "param": "stable-6.8.0-1058.59particle7",
       "abi": "1058",
       // keep this equal to env.PKG_linux_particle below
-      "deb_version": "6.8.0-1058.59+particle6",
+      "deb_version": "6.8.0-1058.59+particle7",
       "base_url": "https://linux-dist.particle.io/kernel/release"
     },
 
@@ -96,8 +96,8 @@
 
   "env": {
     // Kernel version pinned INSIDE the rootfs by the overlay. MUST equal the kernel source
-    // deb_version above (6.8.0-1058.59+particle6) and be installable on the base image's ABI.
-    "PKG_linux_particle": "6.8.0-1058.59+particle6",
+    // deb_version above (6.8.0-1058.59+particle7) and be installable on the base image's ABI.
+    "PKG_linux_particle": "6.8.0-1058.59+particle7",
 
     // Optional: URL to manually install kernel .deb (for unpublished PR builds).
     // Multiple URLs separated by @@@ for related packages (image + modules).


### PR DESCRIPTION
Ships the CVE-2026 IPsec/skb LPE fixes in a 24.04 image. Pin bump only — no code changes.

```diff
-"param": "26-0519f5b"                                  # 24.04 base rootfs
+"param": "27-7f5af3d"
-"param": "stable-6.8.0-1058.59particle6"               # kernel source
+"param": "stable-6.8.0-1058.59particle7"
-"deb_version": "6.8.0-1058.59+particle6"
+"deb_version": "6.8.0-1058.59+particle7"
-"PKG_linux_particle": "6.8.0-1058.59+particle6"        # env
+"PKG_linux_particle": "6.8.0-1058.59+particle7"
```

Four coupled values, plus the two comments that quote them. `versions.json` itself warns that `deb_version` and `env.PKG_linux_particle` must be equal and must match the kernel baked into the base image, or `check-pinned-packages` fails — so they move as one.

## What particle7 contains

Six commits from [kernel#41](https://github.com/particle-iot/tachyon-ubuntu-24.04-kernel/pull/41), released by [kernel#43](https://github.com/particle-iot/tachyon-ubuntu-24.04-kernel/pull/43):

| CVE | Name | Upstream |
|---|---|---|
| CVE-2026-31431 | CopyFail (`crypto/algif_aead`) | `a664bf3d603d` |
| — (follow-up) | `af_alg_pull_tsgl()` one-entry overflow | `31d00156e50e` |
| CVE-2026-43284 | Dirty Frag (xfrm/ESP) | `f4c50a4034e6` |
| CVE-2026-43500 | Dirty Frag (rxrpc) | `aa54b1d27fe0` |
| CVE-2026-43503 | DirtyClone | `48f6a5356a33` |
| CVE-2026-46300 | Fragnesia (`skb_try_coalesce`) | `f84eca581739` |

The 20.04 side is the same family, fixed separately — [tachyon-release-builder#218](https://github.com/particle-iot-inc/tachyon-release-builder/pull/218) — because that line runs msm-5.4 (`SKBTX_SHARED_FRAG`) rather than 6.8 (`SKBFL_SHARED_FRAG`).

## Why the base image moves too

`image-27-7f5af3d` was triggered *after* particle7 reached `packages.particle.io noble-stable`, so the rootfs installed particle7 from apt. Pinning particle7 against `image-26` would put a particle7 modules deb on a particle6 rootfs. ABI is unchanged at **1058**, so the two remain compatible either way, but they should be the same build.

## Pre-flight checks

- All twelve `linux-*particle` packages present in `noble-stable` at `6.8.0-1058.59+particle7`.
- Every fetch URL resolves 200: modules deb (135 MiB), desktop base (2.7 GiB), headless base (1.1 GiB).
- `versions.json` parses after comment-stripping; asserted `deb_version == env.PKG_linux_particle` and that the tag matches `deb_version`; no `particle6` or `26-0519f5b` string survives.

## What CI settles

I could not verify from release metadata that `image-27` actually carries particle7 — it records variant and artifact URL, nothing about the kernel. The ordering is right and the apt channel had particle7 before the build started, but **`check-pinned-packages` in this build is the first hard proof**. If `image-27` somehow got a stale index and built with particle6, this PR fails rather than shipping a mismatch.
