### PR TITLE
versions: overlays 276e9868 -> 43aeed16 (restores /vendor initramfs mount — fixes missing Wi-Fi card)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -51,6 +51,17 @@
     // and lets overlay behaviour change under a composer release. Abbreviated shas do
     // NOT work here -- the server rejects them ("couldn't find remote ref"). Bump this
     // deliberately when you want new overlays.
+    // 43aeed16 (#43) = "Backport the two fixes left behind on feature/new-bp (/vendor from
+    // initramfs, HDMI UCM verb)". Wi-Fi is the reason to take this. link-ath11k-firmware (already
+    // shipped, via overlays #26) symlinks /lib/firmware/updates/ath11k/.../board.bin ->
+    // /vendor/wlan/bdwlang.elf, but /vendor was mounted only by fstab at local-fs.target, ~300ms
+    // AFTER udev autoloads ath11k_pci -- so the board file is missing and the card never appears.
+    // amss.bin/m3.bin are the quieter half: linux-firmware ships same-named blobs, so those
+    // resolved to the upstream file instead of the vendor one with nothing logged. #43 adds an
+    // initramfs init-bottom hook that mounts core_nhlos_a before switch_root, replacing the race
+    // with a fixed ordering. Latent since 1.2.6 -- NOT a 1.2.20 regression; being a race is why it
+    // took two months to get reported. Also restores the HDMI UCM verb split, unrelated but
+    // stranded on the same branch: an unplugged DisplayPort used to fail the whole HiFi verb.
     // 276e9868 = "24.04: ship NetworkManager's connectivity conf so first boot doesn't restart NM"
     // (#40). Adds add-nm-connectivity-check to the 24.04 stack only. It writes the exact bytes
     // particled would otherwise write to /etc/NetworkManager/conf.d/20-connectivity.conf, so on a
@@ -62,7 +73,7 @@
     // dc2f331b (#39) = "set-initial-time: compare against the setup time, not a hardcoded 2024".
     "particle-iot/tachyon-overlay": {
       "type": "git_release",
-      "param": "276e98683712130fcda31f3d91b03e5ca4b8ec86"
+      "param": "43aeed16ee09ee28a32c0d122577b2bd13d34037"
     },
 
     // The overlay TOOL (engine that applies the stack). Provides the `when` env-gate and ENV_*


### PR DESCRIPTION
Picks up [overlays #43](https://github.com/particle-iot/tachyon-overlays/pull/43), which restores two fixes stranded on `feature/new-bp`. Single pin bump.

```diff
 "particle-iot/tachyon-overlay": {
   "type": "git_release",
-  "param": "276e98683712130fcda31f3d91b03e5ca4b8ec86"
+  "param": "43aeed16ee09ee28a32c0d122577b2bd13d34037"
 }
```

## The Wi-Fi bug this fixes

`link-ath11k-firmware` has been shipping **since 1.2.6** and creates:

```
/lib/firmware/updates/ath11k/QCA6698AQ/hw2.1/board.bin -> /vendor/wlan/bdwlang.elf
```

But `/vendor` was mounted only by the fstab entry, at `local-fs.target` — roughly **300 ms after** udev autoloads `ath11k_pci`. At probe time the symlink dangles, `board.bin` has no upstream fallback, and the card never appears.

The quieter half: `amss.bin` and `m3.bin` *do* exist in upstream linux-firmware, so those resolved to the generic blobs instead of the vendor ones with nothing logged. The fstab entry also carries `nofail`, so a failed mount was silent too.

#43 adds an initramfs `init-bottom` hook that mounts `core_nhlos_a` on `${rootmnt}/vendor` before `switch_root`, replacing the race with a fixed ordering. It resolves by `PARTLABEL` with a `blkid` fallback (never a device node — UFS LUN order isn't guaranteed) and `exit 0`s on failure, leaving fstab as the fallback.

**This is not a 1.2.20 regression.** Every release from 1.2.6 onward has the symlinks and lacks the mount. Being a race is why it presented intermittently and took two months to get a clean report — worth knowing before anyone bisects against 1.2.19.

Also included, unrelated but stranded on the same branch: the HDMI UCM verb split, so an unplugged DisplayPort no longer fails the whole HiFi verb and kills all audio.

## How they were lost

`feature/new-bp`'s content reached main on 2026-06-23 via #26 — whose head was `feature/when`, not `feature/new-bp`. The branch was never deleted, stayed live, and took two more commits: `1cfcc1c` direct with no PR, and `8b0f684` via PR #29 opened with `base=feature/new-bp`. #29 was reviewed and merged and shows green; it just merged into a branch that had been dead five weeks.

## Checks

- Pin is a full 40-char sha (abbreviated ones are rejected by the server on `--depth 1` fetch).
- Reproduced the composer's exact fetch — `git fetch --depth 1 origin 43aeed16…` into an empty repo — and confirmed `overlays/add-fstab-mounts/files/mount-vendor` exists at that sha.
- Asserted nothing else in `versions.json` moved: kernel stays `stable-6.8.0-1058.59particle7`, base image stays `27-7f5af3d`.

## Verification this does not cover

`tachyon-overlays` has no CI, so nothing has exercised the backport. The initramfs hook only runs on a real boot, and neither this build nor #43 can prove it works. **Needs a board:** cold boot, confirm the Wi-Fi card enumerates, and check audio with and without DisplayPort connected.
