### PR TITLE
versions: particle-tachyon-ril 0.6.2-1 -> 0.7.0-1 (antenna RF profile, supersedes the modem-rf-config overlay)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -126,22 +126,30 @@
     //Published to `latest`, as every particle-linux release since 0.22.1-1 is.
     "PKG_particle_linux": "0.25.2-1",
 
-    //Radio code (RIL). 0.6.2 fixes three things a 1.2.17 setup run on head2 surfaced.
-    //Slot reporting: QMI marks both physical slots active on this modem, ModemManager
-    //resolves that by naming the last one, so every boot compared slot 2 against a
-    //configured slot 1, asked for a switch the modem refused with a QMI "Internal" error,
-    //and power-cycled the modem on a device already on the right SIM. 0.6.2 reports the
-    //slot the modem is actually using, and waits and retries where a switch is genuinely
-    //needed. Modem-info reads: nothing refreshes them on a timer, so the startup pass --
-    //the one with no earlier value to fall back on -- ran before ModemManager had exported
-    //a modem and left baseband-version and eid reading `unavailable` for the whole boot.
-    //0.6.2 keeps the last known value and re-runs the refresh with widening backoff, so
-    //`unavailable` means "asked, has none" rather than "could not ask". It also stops
-    //reporting a refused ModemManager call as "ModemManager is not answering" -- an error
-    //reply is the service answering -- and defaults TMPDIR in the on-image suites, which
-    //`sudo` strips and `set -u` then aborts on.
-    //Published to the `latest` feed, not `stable`, exactly as 0.6.0-1 and 0.6.1-1 are.
-    "PKG_particle_tachyon_ril": "0.6.2-1",
+    //Radio code (RIL). 0.7.0 configures the modem's RF for the antenna that is
+    //attached, and makes it a switchable profile rather than a one-shot fix. The
+    //SG560D enables 4x4 MIMO on NR5G and LTE by default, which raises the packet
+    //loss rate on the two-element moulded antenna, and NA boards additionally have
+    //to run at reduced TX power for FCC certification -- but an external antenna
+    //adapter is a different aerial, so those settings belong to the antenna and not
+    //to the board. 0.7.0 adds `antenna --set internal|external`, `--get` and
+    //`--list` to ctl plus SetAntenna/GetAntenna on D-Bus, persists the profile in
+    ///etc/particle/antenna.yaml, and defaults to internal -- so a device that
+    //upgrades into this version and has never been configured lands on the
+    //FCC-correct profile. It reads all three settings before writing any of them,
+    //so a modem that cannot answer is left alone rather than half configured: MIMO
+    //written with TX power still at full is exactly the state an NA board is not
+    //certified for. It also refuses to touch a board whose AT+GMR variant is
+    //neither NA nor EM, and resets the modem rather than rebooting the device,
+    //tracking the reset separately from the write because AT+QTXPWR resets the
+    //modem by itself.
+    //This supersedes the modem-rf-config overlay. tachyon-overlays#41 is closed and
+    //never landed on main, so there is nothing to remove alongside this bump; the
+    //package form also reaches devices already in the field through `apt upgrade`
+    //rather than needing an OS image update, and avoids that overlay's first-boot
+    //reboot landing in the middle of setup, cloud claim and eSIM download.
+    //Published to the `latest` feed, not `stable`, exactly as 0.6.x is.
+    "PKG_particle_tachyon_ril": "0.7.0-1",
 
     //The syscon package
     "PKG_particle_tachyon_syscon": "1.0.52-1",


### PR DESCRIPTION
Single-value bump: `env.PKG_particle_tachyon_ril` `0.6.2-1` → `0.7.0-1`, plus the comment block that explains it.

## What 0.7.0 is

[particle-tachyon-ril#62](https://github.com/particle-iot/particle-tachyon-ril/pull/62) — "Configure the modem's RF for the antenna that is attached". Tag `0.7.0` = `c4378fe`.

The SG560D enables 4x4 MIMO on NR5G and LTE by default, which raises the packet loss rate on the two-element moulded antenna; NA boards additionally have to run at reduced TX power for FCC certification. An external antenna adapter is a different aerial, so those settings belong to the **antenna**, not the board — hence a switchable profile rather than a one-shot fix.

- `antenna --set internal|external`, `antenna --get`, `antenna --list` in ctl; `SetAntenna`/`GetAntenna` on D-Bus.
- Profile persists in `/etc/particle/antenna.yaml` and **defaults to `internal`**, so a device that upgrades into this version and was never configured lands on the FCC-correct profile.
- Reads all three settings before writing any of them, so a modem that cannot answer is left alone rather than half configured — MIMO written with TX power still at full is exactly the state an NA board is not certified for.
- Refuses to touch a board whose `AT+GMR` variant is neither NA nor EM.
- Resets the modem instead of rebooting the device, and tracks the reset separately from the write because `AT+QTXPWR` resets the modem by itself.

## It supersedes an overlay — and there is nothing to remove

0.7.0 replaces the `modem-rf-config` overlay, whose first-boot reboot landed in the middle of setup, cloud claim and eSIM download, and which raced rild for `/dev/smd8`.

Checked before writing this PR:

- [tachyon-overlays#41](https://github.com/particle-iot/tachyon-overlays/pull/41) is **CLOSED** and never merged.
- `modem-rf-config` is absent from `overlays/` both at the currently pinned overlay ref `43aeed16` and on `tachyon-overlays` `origin/main`.
- The composer references `modem-rf` / `rf-config` / `antenna` / `QTXPWR` nowhere.

So this bump is standalone — no coupled overlay pin change, unlike #83 and #84.

Shipping the behaviour in the package rather than the overlay also reaches devices already in the field through `apt upgrade`, instead of requiring an OS image update.

## Verification

**The pin is installable.** `0.7.0-1` is published to `latest` — the feed this pin already reads:

\`\`\`
$ curl -sfL https://packages.particle.io/debian/dists/latest/main/binary-arm64/Packages \
    | awk '/^Package: particle-tachyon-ril$/{f=1} f&&/^Version:/{print \$2; f=0}'
... 0.6.0-1  0.6.1-1  0.6.2-1  0.7.0-1
\`\`\`

`latest` is correct and unchanged: the composer has no reference to the `change-particle-repo-to-stable` overlay, and `stable` tops out at `0.4.5-1` — so every ril release since 0.5.x has shipped from `latest`, including the 0.6.2-1 pin this replaces.

**The file still parses, and make resolves the new value.** `versions.json` is JSONC; re-ran the Makefile's own reader (`Makefile:57`, strips `^\s*//.*` then `json.loads`) — note one comment line begins `///etc/particle/...`, which the stripper handles the same as any other:

\`\`\`
parses OK
ril pin = 0.7.0-1
env keys: 5

$ make -p | grep '^ENV_FROM_JSON :=' | tr ',' '\n' | grep ril
PKG_particle_tachyon_ril=0.7.0-1
\`\`\`

**It flows into the image manifest.** `particle-tachyon-ril` is in `compose_24_04.sh:312`'s `src_map`, so the recorded `sources` in `particle_image_v1` pick the new version up with no further change.

## Not covered here

No hardware run. The runtime behaviour — first boot landing on the `internal` profile, and the modem reset replacing the overlay's device reboot — wants a check on a real NA board once an image carrying this is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA